### PR TITLE
exclude deleted files from linter processing

### DIFF
--- a/Plugins/SwiftLintPlugin/PathExtension.swift
+++ b/Plugins/SwiftLintPlugin/PathExtension.swift
@@ -165,6 +165,12 @@ extension Path {
         return FileManager.default.fileExists(atPath: string)
     }
 
+    var isExistingFile: Bool {
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: string, isDirectory: &isDirectory) else { return false }
+        return !isDirectory.boolValue
+    }
+
     var isDirectory: Bool {
         var isDirectory: ObjCBool = false
         guard FileManager.default.fileExists(atPath: string, isDirectory: &isDirectory) else { return false }

--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -201,8 +201,11 @@ struct SwiftLintPlugin {
         let output = try Process(git, ["diff", "HEAD", "--name-only"], workDirectory: path)
             .executeCommand()
 
-        return output.components(separatedBy: "\n").filter { !$0.isEmpty }.map{
-            path.appending(subpath: $0) // absolute path
+        return output.components(separatedBy: "\n").compactMap {
+            guard !$0.isEmpty else { return nil }
+            let absolutePath = path.appending(subpath: $0)
+            guard absolutePath.exists else { return nil }
+            return absolutePath
         }
     }
 

--- a/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
+++ b/Plugins/SwiftLintPlugin/SwiftLintPlugin.swift
@@ -198,13 +198,14 @@ struct SwiftLintPlugin {
         }()
 
         print("Running \(git) diff at \(path)")
-        let output = try Process(git, ["diff", "HEAD", "--name-only"], workDirectory: path)
-            .executeCommand()
+        let output = try Process(git, ["diff", "HEAD", "--name-only"], workDirectory: path).executeCommand().components(separatedBy: "\n")
+        // append non-tracked files
+        + Process(git, ["ls-files", "--others", "--exclude-standard"], workDirectory: path).executeCommand().components(separatedBy: "\n")
 
-        return output.components(separatedBy: "\n").compactMap {
+        return output.compactMap {
             guard !$0.isEmpty else { return nil }
             let absolutePath = path.appending(subpath: $0)
-            guard absolutePath.exists else { return nil }
+            guard absolutePath.isExistingFile else { return nil }
             return absolutePath
         }
     }
@@ -254,7 +255,7 @@ struct SwiftLintPlugin {
 
         target = FakeTarget(displayName: "Target", files: buildFiles)
         let time = Date().timeIntervalSince(start)
-        print("⏰ files parsing took \(String(format: "%.2f", time))s.")
+        print("⏰ parsing took \(String(format: "%.2f", time))s.")
 
         let commands = try createBuildCommands(context: pluginContext, target: target)
 


### PR DESCRIPTION
Task URL: https://app.asana.com/0/1201037661562251/1206803066031565/f
BSK PR: https://github.com/duckduckgo/BrowserServicesKit/pull/774
iOS PR: https://github.com/duckduckgo/iOS/pull/2710
macOS PR: https://github.com/duckduckgo/macos-browser/pull/2601

Release type: Patch

Description:
- follow-up for https://github.com/duckduckgo/apple-toolbox/pull/4
- excluding deleted files from `git diff` result as it causes linter to fail

Steps to test: 
- Validate swiftlint doesn‘t fail when there‘s a deleted file in `git diff`