### PR TITLE
Support creation of PR subtasks for multiple platforms tickets 

### DIFF
--- a/actions/asana-create-pr-subtask/action.yml
+++ b/actions/asana-create-pr-subtask/action.yml
@@ -41,5 +41,5 @@ runs:
             echo "Error: Failed to get Asana user ID for GitHub user ${{ inputs.github-reviewer-user }}"
             exit 1
           else
-            ${{ github.action_path }}/asana-create-pr-subtask.sh ${{ inputs.asana-task-id }} ${{ steps.get-asana-user-id.outputs.user-id }} ${{ steps.get-pr-url.outputs.url }}
+            ${{ github.action_path }}/asana-create-pr-subtask.sh ${{ inputs.asana-task-id }} ${{ steps.get-asana-user-id.outputs.user-id }} ${{ steps.get-pr-url.outputs.url }} ${{ github.repository_name }}
           fi

--- a/actions/asana-create-pr-subtask/asana-create-pr-subtask.sh
+++ b/actions/asana-create-pr-subtask/asana-create-pr-subtask.sh
@@ -51,15 +51,13 @@ _check_pr_subtask_exist() {
 
 	# read each line of the array
 	# extract the task name and trim leading and trailing white spaces
-	# extract the parent name and trim leading and trailing white spaces
 	# extract the assignee name
-	# checks if the task name has 'PR:' prefix and if contains the parent name and if it's assigned to the reviewer
+	# checks if the task name has 'PR:' prefix the repository name as suffix and if it's assigned to the reviewer
 	echo "$response" | jq -c '.[]' | while read -r item; do
 		task_name=$(jq -r '.task_name' <<< "$item" | awk '{$1=$1};1')
-		parent_name=$(jq -r '.parent_name' <<< "$item" | awk '{$1=$1};1')
 		assignee=$(jq -r '.assignee' <<< "$item")
 
-		if [[ "$task_name" == "${pr_prefix} ${parent_name} (${github_repo_name})" && "$assignee" == "$asana_assignee_id" ]]; then
+		if [[ "$task_name" == "${pr_prefix}"*"(${github_repo_name})" && "$assignee" == "$asana_assignee_id" ]]; then
     		echo "$item"
 		fi
 	done


### PR DESCRIPTION
Some tasks require multiple PR for the same ticket. Eg. a PR for iOS and one for macOS.

This PR changes the logic related to ticket creation and check for ticket existance:

- The repository name is now appended to the task name when the PR subtask is created.
- When we check for the task existence we take into consideration the repository name to make sure we can create tasks for iOS and macOS.

Script tests performed on this ticket: https://app.asana.com/0/1206491073346554/1207149982498459/f

 
