### PR TITLE
use exact dependencies

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "46989693916f56d1186bd59ac15124caef896560",
-        "version" : "1.3.1"
+        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
+        "version" : "1.4.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,9 @@ let package = Package(
     ],
     dependencies: [
         // Depend on the Swift 5.9 release of SwiftSyntax
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "509.0.0"),
-        .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", from: "0.2.2"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-syntax.git", exact: "509.1.1"),
+        .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", exact: "0.2.2"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", exact: "1.4.0"),
     ],
     targets: [
         .binaryTarget(


### PR DESCRIPTION
Used versions that iOS is using, except for `swift-macro-testing` which doesn't appear in iOS's list so just used what Xcode resolved to.

Tests:

* Drop into iOS and check it still builds and runs
* Drop into macOS and check it still builds and runs
