### PR TITLE
Storage macro, NestedObservable macro

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser.git",
       "state" : {
-        "revision" : "0fbc8848e389af3bb55c182bc19ca9d5dc2f255b",
-        "version" : "1.4.0"
+        "revision" : "cdd0ef3755280949551dc26dee5de9ddeda89f54",
+        "version" : "1.6.2"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-macro-testing.git",
       "state" : {
-        "revision" : "2de00af725ff4c43c9a90d7893835de312653169",
-        "version" : "0.6.3"
+        "revision" : "9ab11325daa51c7c5c10fcf16c92bac906717c7e",
+        "version" : "0.6.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,8 +17,8 @@ let package = Package(
     dependencies: [
         // Depend on the Swift 5.9 release of SwiftSyntax
         .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"602.0.0"),
-        .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", exact: "0.6.3"),
-        .package(url: "https://github.com/apple/swift-argument-parser.git", exact: "1.4.0"),
+        .package(url: "https://github.com/pointfreeco/swift-macro-testing.git", exact: "0.6.4"),
+        .package(url: "https://github.com/apple/swift-argument-parser.git", exact: "1.6.2"),
     ],
     targets: [
         .binaryTarget(

--- a/Sources/Macros/MacroDefinitions.swift
+++ b/Sources/Macros/MacroDefinitions.swift
@@ -18,20 +18,439 @@
 
 import Foundation
 
-/// Compile-time validated OS version independent URL instantiation from String Literal.
+// MARK: - Storage Macros
+
+/// Generates type-safe KeyValueStoring protocol implementations with automatic key-value storage
 ///
-/// Used to statically validate preset URLs.
-/// The idea is to disable any flaky URL conversions like punycode or no-scheme urls, only 1-1 mapped String Literals can be used.
+/// Attach `@Storage` to a protocol conforming to `KeyValueStoring` (or its variants) to generate:
+/// - Property getters/setters backed by the key-value store
+/// - Publisher properties (`$propertyName`) for observable protocols
+/// - Automatic `objectWillChange` notifications for `ObservableKeyValueStoring`
 ///
-/// Usage: `let url = #URL("https://duckduckgo.com")`
+/// ## Quick Start
 ///
-/// - Note: Strings like "http://💩.la" or "1" are not valid #URL parameter values.
-/// To instantiate a parametrized URL use `URL.appendingPathComponent(_:)` or `URL.appendingParameters(_:allowedReservedCharacters:)`
-/// To instantiate a URL from a String format, use `URL(string:)`
+/// ```swift
+/// import Macros
+/// import Persistence
 ///
-/// - Parameter string: valid URL String Literal with URL scheme
-/// - Returns: URL instance if provided string argument is a valid URL
-/// - Throws: Compile-time error if provided string argument is not a valid URL
+/// @Storage
+/// protocol AppSettings: ObservableKeyValueStoring {
+///     var isFirstLaunch: Bool? { get set }  // By default, key is "isFirstLaunch"
+///     var username: String? { get set }     // By default, key is "username"
+/// }
+///
+/// // Conform any KeyValueStoring implementation
+/// extension UserDefaults: AppSettings {}
+/// extension InMemoryKeyValueStore: AppSettings {}
+///
+/// // Use with type safety and observation
+/// let settings: AppSettings = UserDefaults.standard
+/// settings.isFirstLaunch = false
+/// settings.$username.sink { print($0 ?? "none") }
+/// ```
+///
+/// ## Supported Protocols
+///
+/// - `KeyValueStoring` - Basic storage
+/// - `ThrowingKeyValueStoring` - Throwing storage operations (use `ThrowingValue<T>` properties)
+/// - `ObservableKeyValueStoring` - With publishers and `objectWillChange`
+/// - `ObservableThrowingKeyValueStoring` - Combining both capabilities
+///
+/// ## Property Types
+///
+/// **Standard properties (all protocols except throwing):**
+/// - Must be **optional** (`String?`, `Int?`, `Bool?`)
+/// - Basic types: `Bool`, `Int`, `Double`, `Float`, `String`, `Data`, `Date`, `URL`
+/// - Collections: `Array`, `Dictionary`
+/// - Enums with `RawRepresentable` (String or Int raw values)
+///
+/// **Throwing properties (ThrowingKeyValueStoring protocols only):**
+/// - Read-write: Use `ThrowingValue<T>` (e.g., `var value: ThrowingValue<Int> { get }`)
+///   - `.get()` returns `T?` (optional) and throws errors
+///   - `.set(_:)` accepts `T?` (optional) and throws errors
+/// - Read-only: Use `ThrowingGetter<T>` (e.g., `var readOnly: ThrowingGetter<Int> { get }`)
+///   - `.get()` returns `T?` (optional) and throws errors
+///   - No `.set()` method available (automatically read-only)
+///
+/// ## Custom Keys
+///
+/// **By default, properties use their variable name as the storage key.**
+///
+/// Use `@Key` to override the default key:
+/// ```swift
+/// var username: String? { get set }  // Uses "username" as key (default)
+///
+/// @Key("custom_key")  // Override: uses "custom_key" instead of property name
+/// var property: String? { get set }
+///
+/// @Key("newKey", migratingLegacyKey: "old.key.with.dots")  // Migrate from dotted key
+/// var migrated: String? { get set }
+///
+/// @Key("legacy.key", allowDotsForLegacyKey: true)  // Keep dotted key (⚠️ discouraged, see notes)
+/// var legacy: String? { get set }
+/// ```
+///
+/// ## Excluding Properties
+///
+/// Use `@StorageIgnored` on **properties** you want to exclude from code generation:
+/// ```swift
+/// @StorageIgnored
+/// var customProperty: String? { get }  // Custom implementation required
+/// ```
+///
+/// **Note:** Functions and associated types are automatically ignored - no annotation needed.
+///
+/// ## Observation Behavior
+///
+/// **Property publishers (`$propertyName` and `publisher(for: \.keyPath)`):**
+/// - ✅ Emit the **current value immediately** on subscription
+/// - ✅ Then emit on every subsequent change
+/// - ✅ Work with **all** ObservableKeyValueStoring implementations
+/// ```swift
+/// settings.$username.sink { value in
+///     print(value)  // Prints: current value (or nil), then new values on changes
+/// }
+/// ```
+///
+/// **objectWillChange publisher (for SwiftUI integration):**
+/// - 🎯 **Primary use case:** SwiftUI view updates when @Storage properties change
+/// - ✅ **Works automatically** with all `ObservableKeyValueStoring` / `ObservableThrowingKeyValueStoring` implementations
+/// - ❌ Does **NOT** emit on subscription
+/// - ✅ Only emits on property change
+/// ```swift
+/// // UserDefaults
+/// let defaults: AppSettings = UserDefaults.standard
+/// defaults.objectWillChange.sink {
+///     print("About to change")  // Only prints on change, not on subscription
+/// }
+/// 
+/// // Custom implementations (e.g., InMemoryKeyValueStore)
+/// let mockStore: AppSettings = InMemoryKeyValueStore()
+/// mockStore.objectWillChange.sink { ... }  // ✅ Works automatically
+/// ```
+///
+/// **Implementation Details:**
+/// - **UserDefaults:** Uses KVO observation (set up lazily on first property access)
+/// - **Custom implementations:** Work automatically if they conform to `ObservableKeyValueStoring`
+///   (e.g., `InMemoryKeyValueStore` emits changes in its storage methods)
+///
+/// **For nested observables in ViewModels:** See `@NestedObservable` below for properly forwarding
+/// objectWillChange from nested ObservableObjects to parent ViewModels.
+///
+/// ## ⚠️ Common Pitfalls
+///
+/// 1. **Property declaration requirements differ by protocol type**
+///    ```swift
+///    // Regular protocols - properties must be optional
+///    var count: Int { get set }   // ❌ Compile error
+///    var count: Int? { get set }  // ✅ Correct
+///    
+///    // Throwing protocols - ThrowingValue must be non-optional
+///    var value: ThrowingValue<Int>? { get }  // ❌ Wrong
+///    var value: ThrowingValue<Int> { get }   // ✅ Correct (returns Int? when calling .get())
+///    ```
+///
+/// 2. **Dotted keys discouraged for observable protocols**
+///    ```swift
+///    @Key("com.app.key")  // ❌ Breaks KVO, falls back to slower NotificationCenter
+///    @Key("appKey")  // ✅ Use simple keys for optimal KVO performance
+///    @Key("appKey", migratingLegacyKey: "com.app.key")  // ✅ Migrate from dotted key
+///    @Key("com.app.key", allowDotsForLegacyKey: true)  // ⚠️ Works but slower (NotificationCenter)
+///    ```
+///
+/// 3. **ThrowingValue/ThrowingGetter only for throwing protocols**
+///    ```swift
+///    import Macros
+///    import Persistence
+///    
+///    @Storage
+///    protocol Settings: KeyValueStoring {  // Non-throwing
+///        var value: ThrowingValue<Int> { get }  // ❌ Wrong protocol
+///    }
+///    
+///    @Storage
+///    protocol Settings: ThrowingKeyValueStoring {
+///        var value: ThrowingValue<Int> { get }  // ✅ Read-write throwing
+///        var readOnly: ThrowingGetter<String> { get }  // ✅ Read-only throwing (no @ReadOnlyKey needed)
+///    }
+///    
+///    // UserDefaults can conform to throwing protocols (never actually throws)
+///    extension UserDefaults: Settings {}  // ✅ Works - UserDefaults conforms to throwing protocols
+///    
+///    // Usage:
+///    let settings: Settings = UserDefaults.standard
+///    try settings.value.set(42)  // Never throws in practice
+///    let val = try settings.value.get()  // Never throws in practice
+///    ```
+///
+/// 4. **Type-safe suite/file isolation (especially important for KeyValueFileStore)**
+///    ```swift
+///    // Standard usage (single suite or file):
+///    extension UserDefaults: AppSettings {}  // ✅ Simple, direct extension
+///    extension KeyValueFileStore: CacheSettings {}  // ✅ Simple, direct extension
+///    
+///    // Usage with dependency injection:
+///    class MyService {
+///        let settings: AppSettings
+///        init(settings: AppSettings = .standard) {  // Default parameter
+///            self.settings = settings
+///        }
+///    }
+///    let service = MyService()  // Uses UserDefaults.standard
+///    let customService = MyService(settings: UserDefaults.standard)  // Explicit
+///    
+///    // Type-safe isolation (multiple suites/files that shouldn't mix):
+///    
+///    // UserDefaults - different suites:
+///    final class AppSettings: UserDefaults {
+///        init() { super.init(suiteName: "com.app.settings")! }
+///    }
+///    final class DebugSettings: UserDefaults {
+///        init() { super.init(suiteName: "com.app.debug")! }
+///    }
+///    extension AppSettings: SettingsProtocol {}
+///    extension DebugSettings: DebugProtocol {}
+///    
+///    // KeyValueFileStore - different file paths:
+///    final class UserPreferences: KeyValueFileStore {
+///        init() throws { try super.init(fileURL: preferencesURL) }
+///    }
+///    final class AppCache: KeyValueFileStore {
+///        init() throws { try super.init(fileURL: cacheURL) }
+///    }
+///    extension UserPreferences: PreferencesProtocol {}
+///    extension AppCache: CacheProtocol {}
+///    
+///    // Type safety prevents mixing up suites/files:
+///    func configure(settings: AppSettings) { ... }  // Can't inject DebugSettings!
+///    func load(prefs: UserPreferences) { ... }      // Can't inject AppCache!
+///    ```
+///
+/// 5. **Testability: Use InMemoryKeyValueStore for testing**
+///    ```swift
+///    import Macros
+///    import Persistence
+///    import PersistenceTestingUtils  // For InMemoryKeyValueStore
+///    
+///    // Production: Define @Storage protocol
+///    @Storage
+///    protocol AppSettings: ObservableKeyValueStoring {
+///        var username: String? { get set }
+///        var isEnabled: Bool? { get set }
+///    }
+///    extension UserDefaults: AppSettings {}
+///    
+///    // Tests: Use InMemoryKeyValueStore
+///    extension InMemoryKeyValueStore: AppSettings {}  // ✅ Extend to conform to protocol
+///    
+///    let testSettings = InMemoryKeyValueStore()
+///    let service = MyService(settings: testSettings)
+///    
+///    // For throwing protocols, use InMemoryObservableThrowingKeyValueStore:
+///    @Storage
+///    protocol ThrowingSettings: ObservableThrowingKeyValueStoring {
+///        var value: ThrowingValue<Int> { get }
+///    }
+///    extension InMemoryObservableThrowingKeyValueStore: ThrowingSettings {}
+///    
+///    let throwingTest = InMemoryObservableThrowingKeyValueStore()
+///    throwingTest.throwOnRead = MyError()  // Configure throwing behavior
+///    
+///    // Service with protocol injection
+///    class MyService {
+///        let settings: any AppSettings
+///        init(settings: any AppSettings) { self.settings = settings }
+///    }
+///    ```
+///
+/// ## Access Control
+///
+/// Protocol visibility is propagated to generated code:
+/// ```swift
+/// public protocol Settings { }     // → public generated code
+/// internal protocol Settings { }   // → internal generated code
+/// ```
+///
+/// ## Nested Protocols
+///
+/// Fully supported with proper qualification:
+/// ```swift
+/// import Macros
+/// import Persistence
+///
+/// struct MyService {
+///     @Storage
+///     protocol Settings: KeyValueStoring {
+///         var enabled: Bool? { get set }
+///     }
+/// }
+/// // Generates: extension MyService.Settings { ... }
+/// ```
+///
+@attached(peer, names: suffixed(KeyPathMapping), prefixed(_), suffixed(_observationKey))
+@attached(extension, names: arbitrary)
+public macro Storage()
+    = #externalMacro(module: "MacrosImplementation", type: "StorageMacro")
+
+/// Specifies a custom storage key for a property in `@Storage` protocols
+///
+/// ## Usage
+///
+/// ```swift
+/// import Macros
+/// import Persistence
+///
+/// @Storage
+/// protocol Settings: KeyValueStoring {
+///     var username: String? { get set }  // Uses "username" as key (default)
+///     
+///     @Key("custom_key")  // Override: uses "custom_key" instead of "property"
+///     var property: String? { get set }
+///     
+///     @Key("newKey", migratingLegacyKey: "old.key")  // Auto-migrate from old key
+///     var migrated: String? { get set }
+/// }
+/// ```
+///
+/// **Default behavior:** Without `@Key`, the property name itself is used as the storage key.
+///
+/// ## Legacy Key Migration
+///
+/// Use `migratingLegacyKey` to automatically migrate values from old keys:
+/// - On first read, the value is copied from the legacy key to the new key
+/// - The legacy key is then removed from storage
+/// - Subsequent accesses use only the new key
+///
+/// ## Key Validation
+///
+/// ⚠️ Keys with dots (`.`) break **efficient KVO observation** in `ObservableKeyValueStoring`.
+///
+/// **Solutions (best to worst):**
+/// 1. Use simple keys: `@Key("appKey")` instead of `@Key("com.app.key")`
+/// 2. Migrate from dotted keys: `@Key("appKey", migratingLegacyKey: "com.app.key")`
+/// 3. ⚠️ Override with `allowDotsForLegacyKey: true` (discouraged, see below)
+///
+/// **Notes:**
+/// - Legacy keys used for migration can contain dots (they're not observed)
+/// - Dotted keys with `allowDotsForLegacyKey: true` **DO work** with observable protocols but:
+///   - **UserDefaults:** Falls back to NotificationCenter observation (slower, less efficient than KVO)
+///   - **Custom implementations:** May not work at all unless manually implemented
+/// - **Recommendation:** Migrate to non-dotted keys for observable protocols
+///
+@attached(accessor)
+public macro Key(_ key: StaticString, migratingLegacyKey: StaticString? = nil, allowDotsForLegacyKey: Bool = false)
+    = #externalMacro(module: "MacrosImplementation", type: "KeyMacro")
+
+/// Excludes properties from `@Storage` code generation
+///
+/// Use `@StorageIgnored` **only on properties** that shouldn't generate storage accessors.
+/// Functions and associated types are automatically ignored and don't need this annotation.
+///
+/// ```swift
+/// import Macros
+/// import Persistence
+///
+/// @Storage
+/// protocol Settings: KeyValueStoring {
+///     var storedValue: String? { get set }  // ✅ Generated
+///     
+///     @StorageIgnored
+///     var computedValue: Int? { get }  // ❌ Not generated (custom implementation required)
+///     
+///     // Functions and types are automatically ignored - no annotation needed
+///     func customMethod()  // ✅ No @StorageIgnored needed
+///     associatedtype CustomType  // ✅ No @StorageIgnored needed
+/// }
+/// ```
+@attached(peer)
+public macro StorageIgnored()
+    = #externalMacro(module: "MacrosImplementation", type: "StorageIgnoredMacro")
+
+/// Marks a property as read-only (no setter generated)
+///
+/// Use for properties that are computed or managed externally.
+///
+/// **Note:** `ThrowingGetter<T>` is automatically read-only - no `@ReadOnlyKey` needed.
+///
+/// ```swift
+/// import Macros
+/// import Persistence
+///
+/// @Storage
+/// protocol Settings: KeyValueStoring {
+///     var editable: String? { get set }  // Can write
+///     
+///     @ReadOnlyKey
+///     var readOnly: Int? { get }  // Cannot write
+/// }
+/// ```
+@attached(peer)
+public macro ReadOnlyKey()
+    = #externalMacro(module: "MacrosImplementation", type: "ReadOnlyKeyMacro")
+
+
+// MARK: - SwiftUI & Combine Macros
+
+/// Automatically forwards a nested `ObservableObject`'s change notifications to the parent `ObservableObject`.
+///
+/// Apply this macro to properties of type `ObservableObject` within an `ObservableObject` class.
+/// The macro generates:
+/// - A backing storage variable (`_propertyName`)
+/// - A stored `AnyCancellable` for the subscription (`_propertyNameCancellable`)
+/// - A computed property that manages subscriptions automatically
+///
+/// ## Usage
+///
+/// ```swift
+/// final class ParentModel: ObservableObject {
+///     @NestedObservable var child: ChildModel = ChildModel()
+/// }
+/// ```
+///
+/// ## Generated Code
+///
+/// The macro transforms the property into:
+/// - A backing variable: `private var _child: ChildModel`
+/// - A cancellable: `private var _childCancellable: AnyCancellable?`
+/// - A computed property with getter/setter that:
+///   - Sets up subscription on first access (lazy)
+///   - Re-subscribes when the property is replaced
+///   - Forwards `child.objectWillChange` to `parent.objectWillChange`
+///
+/// ## Notes
+///
+/// - The nested object must conform to `ObservableObject`
+/// - The parent class must conform to `ObservableObject`
+/// - Subscription is set up lazily on first property access
+/// - When the property is set to a new object, the old subscription is cancelled and a new one is created
+///
+@attached(accessor)
+@attached(peer, names: arbitrary)
+public macro NestedObservable()
+    = #externalMacro(module: "MacrosImplementation", type: "NestedObservableMacro")
+
+// MARK: - Utility Macros
+
+/// Compile-time validated URL instantiation from String Literal
+///
+/// Creates URL instances from string literals with compile-time validation.
+/// Rejects invalid URLs, punycode, and no-scheme URLs.
+///
+/// ## Usage
+///
+/// ```swift
+/// let url = #URL("https://duckduckgo.com")  // ✅ Valid
+/// let api = #URL("https://api.example.com/v1")  // ✅ Valid
+///
+/// let bad = #URL("http://💩.la")  // ❌ Compile error
+/// let invalid = #URL("not-a-url")  // ❌ Compile error
+/// ```
+///
+/// ## Note
+///
+/// For dynamic URLs, use `URL(string:)` or URL composition methods:
+/// - `URL.appendingPathComponent(_:)`
+/// - `URL.appendingParameters(_:allowedReservedCharacters:)`
 ///
 @freestanding(expression)
 public macro URL(_ string: StaticString) -> URL = #externalMacro(module: "MacrosImplementation", type: "URLMacro")

--- a/Sources/MacrosImplementation/KeyMacro.swift
+++ b/Sources/MacrosImplementation/KeyMacro.swift
@@ -1,0 +1,182 @@
+//
+//  KeyMacro.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Macro for generating getter/setter for KeyValueStoring-backed properties
+///
+/// This macro generates @objc dynamic accessors that use KeyValueStoring protocol methods.
+/// Works with UserDefaults for KVO observation and any custom KeyValueStoring implementations.
+///
+/// ## Usage
+/// ```swift
+/// extension KeyValueStoring {
+///     @Key("myKey", defaultValue: false)
+///     var myProperty: Bool
+///
+///     @Key("optionalKey")
+///     var optionalProperty: String?
+/// }
+/// ```
+///
+public struct KeyMacro {}
+
+extension KeyMacro: AccessorMacro {
+    
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingAccessorsOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [AccessorDeclSyntax] {
+        
+        guard let varDecl = declaration.as(VariableDeclSyntax.self) else {
+            throw MacroError.message("@Key can only be applied to variable declarations")
+        }
+        
+        guard let binding = varDecl.bindings.first,
+              let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier else {
+            throw MacroError.message("@Key requires a variable declaration")
+        }
+        
+        guard let type = binding.typeAnnotation?.type else {
+            throw MacroError.message("@Key requires an explicit type annotation")
+        }
+        
+        let varName = identifier.text
+        
+        // Extract key, defaultValue, and other arguments from macro arguments
+        var storageKey: String = varName
+        var defaultValueExpr: ExprSyntax?
+        var hasLegacyKey = false
+        var allowDotsForLegacyKey = false
+        
+        if case .argumentList(let arguments) = node.arguments {
+            for argument in arguments {
+                if argument.label == nil, // Positional argument (key)
+                   let stringLiteral = argument.expression.as(StringLiteralExprSyntax.self),
+                   let segment = stringLiteral.segments.first?.as(StringSegmentSyntax.self) {
+                    storageKey = segment.content.text
+                } else if argument.label?.text == "defaultValue" {
+                    defaultValueExpr = argument.expression
+                } else if argument.label?.text == "migratingLegacyKey" {
+                    hasLegacyKey = true
+                } else if argument.label?.text == "allowDotsForLegacyKey" {
+                    if let boolLiteral = argument.expression.as(BooleanLiteralExprSyntax.self),
+                       boolLiteral.literal.text == "true" {
+                        allowDotsForLegacyKey = true
+                    }
+                }
+            }
+        }
+        
+        // Validate key doesn't contain dots (which break KVO observation)
+        if storageKey.contains(".") && !allowDotsForLegacyKey {
+            if hasLegacyKey {
+                // If migratingLegacyKey is present, the dot is in the new key which is wrong
+                throw MacroError.message("""
+                    @Key error: The new key '\(storageKey)' contains a dot (.) which breaks KVO observation.
+                    
+                    The NEW key must not contain dots. Only the legacy key being migrated FROM can have dots.
+                    
+                    Fix: Use a key without dots for the new key:
+                      @Key("newKeyWithoutDots", migratingLegacyKey: "\(storageKey)")
+                    """)
+            } else {
+                // Suggest migration or explicit opt-in
+                throw MacroError.message("""
+                    @Key error: The key '\(storageKey)' contains a dot (.) which breaks KVO observation.
+                    
+                    Keys with dots cannot be observed by ObservableKeyValueStoring protocols.
+                    
+                    Choose one of these solutions:
+                    
+                    1. Migrate to a new key without dots (recommended):
+                       @Key("newKeyWithoutDots", migratingLegacyKey: "\(storageKey)")
+                    
+                    2. If this key will NOT be observed (not used with ObservableKeyValueStoring):
+                       @Key("\(storageKey)", allowDotsForLegacyKey: true)
+                    """)
+            }
+        }
+        
+        // Check if type is optional
+        let isOptional = type.is(OptionalTypeSyntax.self)
+        let typeString = type.trimmedDescription
+        let baseType = typeString.replacingOccurrences(of: "?", with: "")
+        
+        // Skip accessor generation for ThrowingValue types - they're handled by @Storage extension macro
+        if typeString.hasPrefix("ThrowingValue<") {
+            return []
+        }
+        
+        // Generate getter and setter based on type
+        let getterBody = generateGetter(key: storageKey, type: typeString, baseType: baseType, isOptional: isOptional, defaultValue: defaultValueExpr)
+        let setterBody = generateSetter(key: storageKey, type: typeString, baseType: baseType, isOptional: isOptional)
+        
+        return [
+            """
+            get {
+                \(raw: getterBody)
+            }
+            """,
+            """
+            set {
+                \(raw: setterBody)
+            }
+            """
+        ]
+    }
+    
+    private static func generateGetter(key: String, type: String, baseType: String, isOptional: Bool, defaultValue: ExprSyntax?) -> String {
+        let keyLiteral = "\"\(key)\""
+        
+        if isOptional {
+            // For optional types, use object(forKey:) with casting
+            return "object(forKey: \(keyLiteral)) as? \(baseType)"
+        } else {
+            // For non-optional types, require default value
+            guard let defaultValue = defaultValue else {
+                return "((object(forKey: \(keyLiteral))) as? \(type)) ?? /* default value required */"
+            }
+            
+            let defaultExpr = defaultValue.trimmedDescription
+            return "((object(forKey: \(keyLiteral))) as? \(type)) ?? \(defaultExpr)"
+        }
+    }
+    
+    private static func generateSetter(key: String, type: String, baseType: String, isOptional: Bool) -> String {
+        let keyLiteral = "\"\(key)\""
+        
+        if isOptional {
+            return """
+            if let value = newValue {
+                            set(value, forKey: \(keyLiteral))
+                        } else {
+                            removeObject(forKey: \(keyLiteral))
+                        }
+            """
+        } else {
+            return """
+            set(newValue, forKey: \(keyLiteral))
+            """
+        }
+    }
+    
+}

--- a/Sources/MacrosImplementation/MacrosCompilerPlugin.swift
+++ b/Sources/MacrosImplementation/MacrosCompilerPlugin.swift
@@ -23,5 +23,10 @@ import SwiftSyntaxMacros
 struct MacrosCompilerPlugin: CompilerPlugin {
     let providingMacros: [Macro.Type] = [
         URLMacro.self,
+        KeyMacro.self,
+        ReadOnlyKeyMacro.self,
+        StorageIgnoredMacro.self,
+        StorageMacro.self,
+        NestedObservableMacro.self,
     ]
 }

--- a/Sources/MacrosImplementation/NestedObservableMacro.swift
+++ b/Sources/MacrosImplementation/NestedObservableMacro.swift
@@ -1,0 +1,125 @@
+//
+//  NestedObservableMacro.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Macro for generating nested ObservableObject forwarding
+///
+/// This macro transforms a property into a computed property with backing storage
+/// that automatically forwards the nested object's `objectWillChange` to the parent's.
+///
+public struct NestedObservableMacro {}
+
+extension NestedObservableMacro: AccessorMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingAccessorsOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [AccessorDeclSyntax] {
+        
+        guard let varDecl = declaration.as(VariableDeclSyntax.self),
+              let binding = varDecl.bindings.first,
+              let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
+              binding.typeAnnotation != nil else {
+            throw MacroError.message("@NestedObservable can only be applied to variable declarations with explicit type annotations")
+        }
+        
+        // Ensure this is not a computed property already
+        if binding.accessorBlock != nil {
+            throw MacroError.message("@NestedObservable cannot be applied to computed properties")
+        }
+        
+        let propertyName = identifier.identifier.text
+        let backingName = "_\(propertyName)"
+        let cancellableName = "_\(propertyName)Cancellable"
+        
+        // Generate getter that lazily sets up subscription
+        let getter: AccessorDeclSyntax =
+        """
+        get {
+            if \(raw: cancellableName) == nil {
+                \(raw: cancellableName) = \(raw: backingName).objectWillChange.sink { [weak self] _ in
+                    self?.objectWillChange.send()
+                }
+            }
+            return \(raw: backingName)
+        }
+        """
+        
+        // Generate setter that cancels old subscription and sets up new one
+        let setter: AccessorDeclSyntax =
+        """
+        set {
+            \(raw: cancellableName)?.cancel()
+            \(raw: backingName) = newValue
+            \(raw: cancellableName) = \(raw: backingName).objectWillChange.sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            objectWillChange.send()
+        }
+        """
+        
+        return [getter, setter]
+    }
+}
+
+extension NestedObservableMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        
+        guard let varDecl = declaration.as(VariableDeclSyntax.self),
+              let binding = varDecl.bindings.first,
+              let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
+              let typeAnnotation = binding.typeAnnotation else {
+            return []
+        }
+        
+        let propertyName = identifier.identifier.text
+        let typeString = typeAnnotation.type.trimmedDescription
+        let backingName = "_\(propertyName)"
+        let cancellableName = "_\(propertyName)Cancellable"
+        
+        // Get initial value if present
+        let initialValue: String
+        if let initValue = binding.initializer?.value {
+            initialValue = " = \(initValue.trimmedDescription)"
+        } else {
+            initialValue = ""
+        }
+        
+        // Generate backing storage
+        let backingStorage: DeclSyntax =
+        """
+        private var \(raw: backingName): \(raw: typeString)\(raw: initialValue)
+        """
+        
+        // Generate cancellable storage
+        let cancellableStorage: DeclSyntax =
+        """
+        private var \(raw: cancellableName): AnyCancellable?
+        """
+        
+        return [backingStorage, cancellableStorage]
+    }
+}
+

--- a/Sources/MacrosImplementation/ReadOnlyKeyMacro.swift
+++ b/Sources/MacrosImplementation/ReadOnlyKeyMacro.swift
@@ -1,0 +1,27 @@
+//
+//  ReadOnlyKeyMacro.swift
+//  MacrosImplementation
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// Marks a property as read-only in storage protocols
+/// Properties marked with @ReadOnlyKey will:
+/// - Not generate setters
+/// - Not support setValue(_:for:) mutations
+/// - Be computed from other sources or external storage
+public struct ReadOnlyKeyMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        // This macro doesn't generate any peer declarations
+        // It's used as a marker attribute that StorageMacro checks for
+        return []
+    }
+}
+

--- a/Sources/MacrosImplementation/StorageIgnoredMacro.swift
+++ b/Sources/MacrosImplementation/StorageIgnoredMacro.swift
@@ -1,0 +1,38 @@
+//
+//  StorageIgnoredMacro.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+/// No-op macro that serves as a marker for @Storage conformance generator macro to ignore members
+public struct StorageIgnoredMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        // This macro doesn't generate anything - it just marks declarations
+        // for @Storage conformance generator macro to ignore
+        return []
+    }
+}
+
+
+
+
+

--- a/Sources/MacrosImplementation/StorageMacro.swift
+++ b/Sources/MacrosImplementation/StorageMacro.swift
@@ -1,0 +1,786 @@
+//
+//  StorageMacro.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+/// Macro for generating KeyValueStoring implementations for protocol conformances
+///
+/// This macro adds protocol conformance and generates @objc dynamic property implementations.
+///
+/// ## Type Handling Strategy:
+/// - **Explicitly rejected during macro expansion**: Tuples and closures (produce macro diagnostic errors)
+/// - **Treated as basic types**: Bool, Int, Double, Float, String, Data, Date, URL, Array, Dictionary
+/// - **All other types**: Generated as potentially RawRepresentable, will fail at Swift compile-time if they:
+///   - Don't conform to RawRepresentable
+///   - Have a RawValue that isn't storable in UserDefaults
+///   - Can't be serialized by KeyValueStoring implementation
+///
+/// This permissive approach lets Swift's type system provide better error messages than macro diagnostics.
+///
+public struct StorageMacro {}
+
+// MARK: - Helper Functions
+
+/// Builds a fully qualified name for a protocol, including parent types for nested protocols
+///
+/// Walks up the syntax tree to find all parent types (struct, class, enum, actor, extension)
+/// and builds the fully qualified name (e.g., "AppConfig.Settings").
+///
+/// The ExtensionMacro also receives this qualified name via the `type` parameter.
+private func buildQualifiedName(for protocolDecl: ProtocolDeclSyntax, in context: some MacroExpansionContext) -> String {
+    var names: [String] = [protocolDecl.name.text]
+    
+    // Walk up the entire parent chain
+    var currentNode: Syntax? = Syntax(protocolDecl).parent
+    var visitedTypes: Set<String> = []
+    
+    while let node = currentNode {
+        defer { currentNode = node.parent }
+        
+        // Extract type names from various parent nodes
+        if let structDecl = node.as(StructDeclSyntax.self), !visitedTypes.contains(structDecl.name.text) {
+            visitedTypes.insert(structDecl.name.text)
+            names.insert(structDecl.name.text, at: 0)
+            #if DEBUG
+            print("buildQualifiedName - Found struct: \(structDecl.name.text)")
+            #endif
+        } else if let classDecl = node.as(ClassDeclSyntax.self), !visitedTypes.contains(classDecl.name.text) {
+            visitedTypes.insert(classDecl.name.text)
+            names.insert(classDecl.name.text, at: 0)
+        } else if let enumDecl = node.as(EnumDeclSyntax.self), !visitedTypes.contains(enumDecl.name.text) {
+            visitedTypes.insert(enumDecl.name.text)
+            names.insert(enumDecl.name.text, at: 0)
+        } else if let actorDecl = node.as(ActorDeclSyntax.self), !visitedTypes.contains(actorDecl.name.text) {
+            visitedTypes.insert(actorDecl.name.text)
+            names.insert(actorDecl.name.text, at: 0)
+        } else if let extensionDecl = node.as(ExtensionDeclSyntax.self) {
+            // For extensions, get the extended type name
+            let extendedTypeName: String
+            if let identType = extensionDecl.extendedType.as(IdentifierTypeSyntax.self) {
+                extendedTypeName = identType.name.text
+            } else if let memberType = extensionDecl.extendedType.as(MemberTypeSyntax.self) {
+                extendedTypeName = memberType.trimmedDescription
+            } else {
+                continue
+            }
+            
+            if !visitedTypes.contains(extendedTypeName) {
+                visitedTypes.insert(extendedTypeName)
+                names.insert(extendedTypeName, at: 0)
+            }
+        }
+    }
+    
+    return names.joined(separator: ".")
+}
+
+extension StorageMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let protocolDecl = declaration.as(ProtocolDeclSyntax.self) else {
+            return []
+        }
+        
+        // Build fully qualified name for nested protocols
+        let protocolName = buildQualifiedName(for: protocolDecl, in: context)
+        let helperEnumName = protocolName + "KeyPathMapping"
+        
+        var keyPathMappings: [(propertyName: String, storageKey: String, typeString: String)] = []
+        
+        // Read property declarations from the protocol
+        for member in protocolDecl.memberBlock.members {
+            // Skip if marked with @StorageIgnored
+            if let decl = member.decl.asProtocol(WithAttributesSyntax.self),
+               decl.attributes.contains(where: { attr in
+                   guard let attr = attr.as(AttributeSyntax.self),
+                         let identType = attr.attributeName.as(IdentifierTypeSyntax.self) else {
+                       return false
+                   }
+                   return identType.name.text == "StorageIgnored"
+               }) {
+                continue
+            }
+            
+            guard let varDecl = member.decl.as(VariableDeclSyntax.self),
+                  let binding = varDecl.bindings.first,
+                  let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
+                  let typeAnnotation = binding.typeAnnotation else {
+                continue
+            }
+            
+            let propertyName = identifier.identifier.text
+            let typeString = typeAnnotation.type.trimmedDescription
+            let (storageKey, _) = extractStorageKeys(from: varDecl, propertyName: propertyName)
+            
+            keyPathMappings.append((propertyName: propertyName, storageKey: storageKey, typeString: typeString))
+        }
+        
+        // Generate static dictionary mapping keypaths to storage keys
+        let dictEntries = keyPathMappings.map { mapping in
+            "\\\(protocolName).\(mapping.propertyName): \"\(mapping.storageKey)\""
+        }.joined(separator: ",\n        ")
+        
+        // Generate helper enum as peer declaration with qualified name
+        let helperEnum: DeclSyntax =
+        """
+        private enum \(raw: helperEnumName) {
+            static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                \(raw: dictEntries)
+            ]
+        }
+        """
+        
+        return [helperEnum]
+    }
+}
+
+extension StorageMacro: ExtensionMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        
+        guard let protocolDecl = declaration.as(ProtocolDeclSyntax.self) else {
+            throw MacroError.message("@Storage can only be applied to protocol declarations")
+        }
+        
+        // Use the 'type' parameter which already contains the qualified name for nested types
+        let protocolName = type.trimmedDescription
+        let helperEnumName = protocolName + "KeyPathMapping"
+        
+        // Check which storage protocol is being used
+        let inheritedTypes = protocolDecl.inheritanceClause?.inheritedTypes.map { $0.type.trimmedDescription } ?? []
+        let isObservableKeyValueStoring = inheritedTypes.contains(where: { $0.contains("ObservableKeyValueStoring") && !$0.contains("ObservableThrowingKeyValueStoring") })
+        let isObservableThrowingKeyValueStoring = inheritedTypes.contains(where: { $0.contains("ObservableThrowingKeyValueStoring") })
+        let isThrowingKeyValueStoring = inheritedTypes.contains(where: { $0.contains("ThrowingKeyValueStoring") && !$0.contains("ObservableThrowingKeyValueStoring") })
+        let isKeyValueStoring = inheritedTypes.contains(where: { $0.contains("KeyValueStoring") && !$0.contains("ObservableKeyValueStoring") && !$0.contains("ThrowingKeyValueStoring") })
+        
+        // Count how many storage protocols are inherited
+        let storageProtocolCount = [isObservableKeyValueStoring, isObservableThrowingKeyValueStoring, isThrowingKeyValueStoring, isKeyValueStoring].filter { $0 }.count
+        
+        // Validate exactly one storage protocol is inherited
+        guard storageProtocolCount > 0 else {
+            throw MacroError.message("@Storage requires the protocol to inherit from exactly one of: KeyValueStoring, ThrowingKeyValueStoring, ObservableKeyValueStoring, or ObservableThrowingKeyValueStoring")
+        }
+        
+        guard storageProtocolCount == 1 else {
+            let inherited = inheritedTypes.filter { type in
+                type.contains("KeyValueStoring") || type.contains("ThrowingKeyValueStoring") || 
+                type.contains("ObservableKeyValueStoring") || type.contains("ObservableThrowingKeyValueStoring")
+            }
+            throw MacroError.message("@Storage protocol cannot inherit from multiple storage protocols. Found: \(inherited.joined(separator: ", ")). Choose exactly one.")
+        }
+        
+        // Extract access level from protocol declaration
+        let accessLevel = protocolDecl.modifiers.first(where: { modifier in
+            ["public", "internal", "private", "fileprivate", "open"].contains(modifier.name.text)
+        })?.name.text ?? "internal"
+        
+        // Generate access modifier string (empty for internal)
+        let accessModifier = accessLevel == "internal" ? "" : "\(accessLevel) "
+        
+        var generatedProperties: [DeclSyntax] = []
+        var observableProperties: [DeclSyntax] = []
+        var allStorageKeys: [String] = []
+
+        // Read property declarations from the protocol
+        for member in protocolDecl.memberBlock.members {
+            // Skip if marked with @StorageIgnored
+            if let decl = member.decl.asProtocol(WithAttributesSyntax.self),
+               decl.attributes.contains(where: { attr in
+                   guard let attr = attr.as(AttributeSyntax.self),
+                         let identType = attr.attributeName.as(IdentifierTypeSyntax.self) else {
+                       return false
+                   }
+                   return identType.name.text == "StorageIgnored"
+               }) {
+                continue
+            }
+            
+            guard let varDecl = member.decl.as(VariableDeclSyntax.self),
+                  let binding = varDecl.bindings.first,
+                  let identifier = binding.pattern.as(IdentifierPatternSyntax.self),
+                  let typeAnnotation = binding.typeAnnotation else {
+                continue
+            }
+            
+            let propertyName = identifier.identifier.text
+            let typeString = typeAnnotation.type.trimmedDescription
+            let baseType = typeString.replacingOccurrences(of: "?", with: "")
+            let isOptional = typeAnnotation.type.is(OptionalTypeSyntax.self)
+            
+            // Check if this is a ThrowingValue<T> or ThrowingGetter<T> type
+            let isThrowingValue = typeString.hasPrefix("ThrowingValue<")
+            let isThrowingGetter = typeString.hasPrefix("ThrowingGetter<")
+            let isThrowingType = isThrowingValue || isThrowingGetter
+            
+            // Validate that Throwing protocols require ThrowingValue/ThrowingGetter types
+            if (isThrowingKeyValueStoring || isObservableThrowingKeyValueStoring) && !isThrowingType {
+                throw MacroError.message("@Storage with ThrowingKeyValueStoring requires properties to use ThrowingValue<T> or ThrowingGetter<T>. Property '\(propertyName)' has type '\(typeString)'. Use 'var \(propertyName): ThrowingValue<\(baseType)> { get }' for read-write or 'var \(propertyName): ThrowingGetter<\(baseType)> { get }' for read-only.")
+            }
+            
+            // Validate that ThrowingValue/ThrowingGetter can only be used with Throwing protocols
+            if isThrowingType && !isThrowingKeyValueStoring && !isObservableThrowingKeyValueStoring {
+                throw MacroError.message("@Storage property '\(propertyName)' uses \(isThrowingValue ? "ThrowingValue<T>" : "ThrowingGetter<T>") but the protocol '\(protocolName)' does not conform to ThrowingKeyValueStoring or ObservableThrowingKeyValueStoring. Either change the property to a regular optional type or make the protocol conform to a throwing protocol.")
+            }
+            
+            // Validate that non-throwing properties must be optional (ThrowingValue/ThrowingGetter are always non-optional by design)
+            if !isThrowingType && !isOptional {
+                throw MacroError.message("@Storage property '\(propertyName)' must be optional. Change '\(typeString)' to '\(typeString)?'. Only ThrowingValue<T> and ThrowingGetter<T> properties can be non-optional.")
+            }
+            
+            // Validate ThrowingValue/ThrowingGetter properties are read-only
+            if isThrowingType {
+                if let accessorBlock = binding.accessorBlock {
+                    let accessorText = accessorBlock.trimmedDescription
+                    // Check if it has 'set' accessor
+                    if accessorText.contains("set") {
+                        throw MacroError.message("@Storage with \(isThrowingValue ? "ThrowingValue" : "ThrowingGetter") requires read-only properties. Property '\(propertyName)' must be declared as '{ get }', not '{ get set }'.")
+                    }
+                }
+            }
+            
+            // Only support optional types (unless it's ThrowingValue/ThrowingGetter which handle optionality differently)
+            guard isOptional || isThrowingType else {
+                throw MacroError.message("@Storage only supports optional property types. Property '\(propertyName)' with type '\(typeString)' must be optional (e.g., '\(typeString)?'). Non-optional types would require implicit default values which hide missing data.")
+            }
+            
+            // Check if type is a known basic type or potentially RawRepresentable
+            let isBasicType = isSupportedType(baseType)
+            
+            // Reject types that are clearly not supported (tuples, closures, etc.)
+            if baseType.contains("(") && baseType.contains("->") {
+                throw MacroError.message("@Storage does not support closure type '\(baseType)' for property '\(propertyName)'. Use @StorageIgnored to exclude this property.")
+            }
+            if baseType.hasPrefix("(") && baseType.hasSuffix(")") && baseType.contains(",") {
+                throw MacroError.message("@Storage does not support tuple type '\(baseType)' for property '\(propertyName)'. Use @StorageIgnored to exclude this property.")
+            }
+            
+            // Check for @Key attribute to get custom key and legacy key
+            let (storageKey, legacyKey) = extractStorageKeys(from: varDecl, propertyName: propertyName)
+            
+            // Track all storage keys for observation setup
+            allStorageKeys.append(storageKey)
+            
+            // For pure ThrowingKeyValueStoring, require ThrowingValue<T> or ThrowingGetter<T>
+            if isThrowingKeyValueStoring && !isKeyValueStoring && !isObservableKeyValueStoring && !isObservableThrowingKeyValueStoring {
+                guard isThrowingType else {
+                    throw MacroError.message("@Storage with ThrowingKeyValueStoring requires properties to use ThrowingValue<T> or ThrowingGetter<T>. Property '\(propertyName)' has type '\(typeString)'. Use 'var \(propertyName): ThrowingValue<\(typeString)> { get }' for read-write or 'var \(propertyName): ThrowingGetter<\(typeString)> { get }' for read-only.")
+                }
+            }
+            
+            // Generate property implementation
+            let property: DeclSyntax
+            
+            if isThrowingType {
+                // Extract inner type from ThrowingValue<T> or ThrowingGetter<T>
+                let prefix = isThrowingValue ? "ThrowingValue<" : "ThrowingGetter<"
+                let innerType = String(typeString.dropFirst(prefix.count).dropLast(1))
+                let innerIsOptional = innerType.hasSuffix("?")
+                
+                // ThrowingValue/ThrowingGetter inner type must be non-optional
+                guard !innerIsOptional else {
+                    throw MacroError.message("@Storage with \(isThrowingValue ? "ThrowingValue" : "ThrowingGetter") requires the inner type to be non-optional. Property '\(propertyName)' has type '\(typeString)' but should be '\(prefix)\(innerType.replacingOccurrences(of: "?", with: ""))>'.")
+                }
+                
+                let innerBaseType = innerType  // Already non-optional
+                let innerIsBasicType = isSupportedType(innerBaseType)
+                
+                // Generate ThrowingValue/ThrowingGetter property (read-only)
+                // The getter/setter operate on T? (optional) even though ThrowingValue<T> is non-optional
+                property = generateThrowingValueProperty(
+                    accessModifier: accessModifier,
+                    propertyName: propertyName,
+                    outerType: typeString,
+                    innerType: innerType,
+                    innerBaseType: innerBaseType,
+                    innerIsBasicType: innerIsBasicType,
+                    storageKey: storageKey,
+                    legacyKey: legacyKey,
+                    isReadOnly: isThrowingGetter
+                )
+            } else {
+                // Regular property for KeyValueStoring/ObservableKeyValueStoring
+                let getterBody = generateGetter(key: storageKey, legacyKey: legacyKey, type: typeString, baseType: baseType, isOptional: isOptional, isBasicType: isBasicType, setupObservation: isObservableKeyValueStoring, isThrowing: isThrowingKeyValueStoring)
+                
+                let useTryInternally = isObservableThrowingKeyValueStoring && !isKeyValueStoring
+                let getterBodyNonThrowing = useTryInternally ? 
+                    generateGetter(key: storageKey, legacyKey: legacyKey, type: typeString, baseType: baseType, isOptional: isOptional, isBasicType: isBasicType, setupObservation: isObservableThrowingKeyValueStoring, isThrowing: false).replacingOccurrences(of: "self.object", with: "try? self.object").replacingOccurrences(of: "self.removeObject", with: "try? self.removeObject") :
+                    getterBody
+                let setterBody = generateSetter(key: storageKey, legacyKey: legacyKey, type: typeString, baseType: baseType, isOptional: isOptional, isBasicType: isBasicType, isThrowing: useTryInternally)
+                property =
+                """
+                \(raw: accessModifier)var \(raw: propertyName): \(raw: typeString) {
+                    get {
+                        \(raw: getterBodyNonThrowing)
+                    }
+                    set {
+                        \(raw: setterBody)
+                    }
+                }
+                """
+            }
+            
+            generatedProperties.append(property)
+            
+            // Generate publisher property using string-based KVO (only for observable protocols, skip for ThrowingValue/ThrowingGetter types)
+            if (isObservableKeyValueStoring || isObservableThrowingKeyValueStoring) && !isThrowingType {
+                let publisher: DeclSyntax =
+                """
+                \(raw: accessModifier)var $\(raw: propertyName): AnyPublisher<\(raw: typeString), Never> {
+                    publisher(for: \\\(raw: protocolName).\(raw: propertyName), key: "\(raw: storageKey)")
+                }
+                """
+                
+                observableProperties.append(publisher)
+            }
+        }
+        
+        // Add helper functions for KeyPath-based observation (only for observable protocols)
+        if isObservableKeyValueStoring {
+            // For ObservableKeyValueStoring: KeyPath<Protocol, Value?>
+            let publicHelperFunction: DeclSyntax =
+            """
+            \(raw: accessModifier)func publisher<Value>(for keyPath: KeyPath<\(raw: protocolName), Value?>) -> AnyPublisher<Value?, Never> {
+                guard let key = \(raw: helperEnumName).keyPathToStorageKey[keyPath] else {
+                    fatalError("Unknown keyPath: \\(keyPath)")
+                }
+                return publisher(for: keyPath, key: key)
+            }
+            """
+            observableProperties.append(publicHelperFunction)
+
+            let helperFunction: DeclSyntax =
+            """
+            private func publisher<Value>(for keyPath: KeyPath<\(raw: protocolName), Value?>, key: String) -> AnyPublisher<Value?, Never> {
+                self.updatesPublisher(forKey: key)
+                    .prepend( () )
+                    .map {
+                        self[keyPath: keyPath]
+                    }
+                    .eraseToAnyPublisher()
+            }
+            """
+            observableProperties.append(helperFunction)
+        } else if isObservableThrowingKeyValueStoring {
+            // For ObservableThrowingKeyValueStoring: KeyPath<Protocol, ThrowingValue<Value>>
+            let publicHelperFunction: DeclSyntax =
+            """
+            \(raw: accessModifier)func publisher<Value>(for keyPath: KeyPath<\(raw: protocolName), ThrowingValue<Value>>) -> AnyPublisher<Value?, Never> {
+                guard let key = \(raw: helperEnumName).keyPathToStorageKey[keyPath] else {
+                    fatalError("Unknown keyPath: \\(keyPath)")
+                }
+                return publisher(for: keyPath, key: key)
+            }
+            """
+            observableProperties.append(publicHelperFunction)
+
+            let helperFunction: DeclSyntax =
+            """
+            private func publisher<Value>(for keyPath: KeyPath<\(raw: protocolName), ThrowingValue<Value>>, key: String) -> AnyPublisher<Value?, Never> {
+                self.updatesPublisher(forKey: key)
+                    .prepend( () )
+                    .map { [weak self] in
+                        try? self?[keyPath: keyPath].get()
+                    }
+                    .eraseToAnyPublisher()
+            }
+            """
+            observableProperties.append(helperFunction)
+        }
+        
+        // Generate automatic observation setup for UserDefaults conformances (only for ObservableKeyValueStoring and ObservableThrowingKeyValueStoring)
+        if !allStorageKeys.isEmpty && (isObservableKeyValueStoring || isObservableThrowingKeyValueStoring) {
+            let keysArray = allStorageKeys.map { "\"\($0)\"" }.joined(separator: ", ")
+            let sanitizedName = protocolName.replacingOccurrences(of: ".", with: "_")
+            let selectorString = "_\(sanitizedName)_observationCancellable"
+            
+            let setupMethod: DeclSyntax =
+            """
+            private var _\(raw: sanitizedName)_observationCancellable: AnyCancellable? {
+                get {
+                    guard let userDefaults = self as? UserDefaults else { return nil }
+                    let key = unsafeBitCast(Selector(("\(raw: selectorString)")), to: UnsafeRawPointer.self)
+                    return objc_getAssociatedObject(userDefaults, key) as? AnyCancellable
+                }
+                set {
+                    guard let userDefaults = self as? UserDefaults else { return }
+                    let key = unsafeBitCast(Selector(("\(raw: selectorString)")), to: UnsafeRawPointer.self)
+                    objc_setAssociatedObject(userDefaults, key, newValue, .OBJC_ASSOCIATION_RETAIN)
+                }
+            }
+            
+            private func _setupAutoObservationIfNeeded() {
+                guard let userDefaults = self as? UserDefaults else { return }
+                
+                if _\(raw: sanitizedName)_observationCancellable != nil {
+                    return
+                }
+                
+                // Subscribe to all publishers for keys in this protocol
+                let keys = [\(raw: keysArray)]
+                let publishers = keys.map { userDefaults.updatesPublisher(forKey: $0) }
+                
+                let cancellable = Publishers.MergeMany(publishers)
+                    .sink { [weak userDefaults] _ in
+                        userDefaults?.objectWillChange.send()
+                    }
+                
+                _\(raw: sanitizedName)_observationCancellable = cancellable
+            }
+            """
+            observableProperties.append(setupMethod)
+        }
+
+        // Create extension without where clause (protocol should inherit from KeyValueStoring)
+        let extensionDecl = try ExtensionDeclSyntax(
+            """
+            extension \(raw: protocolName)
+            """
+        ) {
+            for property in generatedProperties {
+                property
+            }
+        }
+        
+        // Only generate observable extension if there are observable properties
+        var extensions = [extensionDecl]
+        
+        if !observableProperties.isEmpty {
+            // Generate extension for both ObservableKeyValueStoring and ObservableThrowingKeyValueStoring
+            let observableWhereClause = isObservableThrowingKeyValueStoring ? 
+                "where Self: ObservableThrowingKeyValueStoring" :
+                "where Self: ObservableKeyValueStoring"
+            
+            let extensionDecl2 = try ExtensionDeclSyntax(
+                """
+                extension \(raw: protocolName) \(raw: observableWhereClause)
+                """
+            ) {
+                for property in observableProperties {
+                    property
+                }
+            }
+            extensions.append(extensionDecl2)
+        }
+        
+        return extensions
+    }
+    
+    private static func extractStorageKeys(from varDecl: VariableDeclSyntax, propertyName: String) -> (key: String, legacyKey: String?) {
+        // Look for @Key attribute
+        for attribute in varDecl.attributes {
+            guard let attr = attribute.as(AttributeSyntax.self),
+                  let identType = attr.attributeName.as(IdentifierTypeSyntax.self),
+                  identType.name.text == "Key" else {
+                continue
+            }
+            
+            // Extract the key and migratingLegacyKey arguments from @Key("key", migratingLegacyKey: "old.key")
+            if case .argumentList(let arguments) = attr.arguments {
+                var key: String?
+                var legacyKey: String?
+                
+                for arg in arguments {
+                    if arg.label == nil, // Positional argument (first = key)
+                       let stringLiteral = arg.expression.as(StringLiteralExprSyntax.self),
+                       let segment = stringLiteral.segments.first?.as(StringSegmentSyntax.self) {
+                        key = segment.content.text
+                    } else if arg.label?.text == "migratingLegacyKey",
+                              let stringLiteral = arg.expression.as(StringLiteralExprSyntax.self),
+                              let segment = stringLiteral.segments.first?.as(StringSegmentSyntax.self) {
+                        legacyKey = segment.content.text
+                    }
+                }
+                
+                if let key = key {
+                    return (key: key, legacyKey: legacyKey)
+                }
+            }
+        }
+        
+        return (key: propertyName, legacyKey: nil)
+    }
+    
+    private static func isSupportedType(_ typeString: String) -> Bool {
+        // Basic types
+        let basicTypes = ["Bool", "Int", "Double", "Float", "String", "Data", "Date", "URL"]
+        if basicTypes.contains(typeString) {
+            return true
+        }
+        
+        // Array types: [Type] or Array<Type>
+        if typeString.hasPrefix("[") && typeString.hasSuffix("]") {
+            return true
+        }
+        if typeString.hasPrefix("Array<") && typeString.hasSuffix(">") {
+            return true
+        }
+        
+        // Dictionary types: [Key: Value] or Dictionary<Key, Value>
+        if typeString.contains(":") && typeString.hasPrefix("[") && typeString.hasSuffix("]") {
+            return true
+        }
+        if typeString.hasPrefix("Dictionary<") && typeString.hasSuffix(">") {
+            return true
+        }
+        
+        return false
+    }
+    
+    private static func generateThrowingValueProperty(
+        accessModifier: String,
+        propertyName: String,
+        outerType: String,
+        innerType: String,
+        innerBaseType: String,
+        innerIsBasicType: Bool,
+        storageKey: String,
+        legacyKey: String?,
+        isReadOnly: Bool = false
+    ) -> DeclSyntax {
+        let keyLiteral = "\"\(storageKey)\""
+        
+        // Generate getter closure (always returns T? - optional)
+        let getterClosure: String
+        if innerIsBasicType {
+            if let legacyKey = legacyKey {
+                // With legacy key migration
+                let legacyKeyLiteral = "\"\(legacyKey)\""
+                getterClosure = """
+{
+    if let value = try self.object(forKey: \(keyLiteral)) as? \(innerBaseType) {
+        return value
+    }
+    // Migration: check legacy key
+    if let legacyValue = try self.object(forKey: \(legacyKeyLiteral)) as? \(innerBaseType) {
+        try self.set(legacyValue, forKey: \(keyLiteral))
+        try self.removeObject(forKey: \(legacyKeyLiteral))
+        return legacyValue
+    }
+    return nil
+}
+"""
+            } else {
+                // No legacy key
+                getterClosure = """
+{
+    return try self.object(forKey: \(keyLiteral)) as? \(innerBaseType)
+}
+"""
+            }
+        } else {
+            // Enum or other RawRepresentable type (always returns T? - optional)
+            if let legacyKey = legacyKey {
+                let legacyKeyLiteral = "\"\(legacyKey)\""
+                getterClosure = """
+{
+    if let rawValue = try self.object(forKey: \(keyLiteral)), let value = (\(innerType))(rawValue: rawValue as! \(innerType).RawValue) {
+        return value
+    }
+    // Migration
+    if let legacyRawValue = try self.object(forKey: \(legacyKeyLiteral)), let legacyValue = (\(innerType))(rawValue: legacyRawValue as! \(innerType).RawValue) {
+        if let rawValue = (legacyValue as? any RawRepresentable)?.rawValue {
+            try self.set(rawValue, forKey: \(keyLiteral))
+        }
+        try self.removeObject(forKey: \(legacyKeyLiteral))
+        return legacyValue
+    }
+    return nil
+}
+"""
+            } else {
+                getterClosure = """
+{
+    guard let rawValue = try self.object(forKey: \(keyLiteral)) else { return nil }
+    return (\(innerType))(rawValue: rawValue as! \(innerType).RawValue)
+}
+"""
+            }
+        }
+        
+        // Generate setter closure (always takes T? - optional)
+        let setterClosure: String
+        if innerIsBasicType {
+            setterClosure = """
+{ newValue in
+    if let newValue = newValue {
+        try self.set(newValue, forKey: \(keyLiteral))
+    } else {
+        try self.removeObject(forKey: \(keyLiteral))
+    }
+}
+"""
+        } else {
+            // Enum or RawRepresentable (always takes T? - optional)
+            setterClosure = """
+{ newValue in
+    if let newValue = newValue {
+        if let rawValue = (newValue as? any RawRepresentable)?.rawValue {
+            try self.set(rawValue, forKey: \(keyLiteral))
+        } else {
+            try self.set(newValue, forKey: \(keyLiteral))
+        }
+    } else {
+        try self.removeObject(forKey: \(keyLiteral))
+    }
+}
+"""
+        }
+        
+        if isReadOnly {
+            // Generate ThrowingGetter (read-only, no setter)
+            return """
+            \(raw: accessModifier)var \(raw: propertyName): \(raw: outerType) {
+                get {
+                    ThrowingGetter(
+                        getter: \(raw: getterClosure)
+                    )
+                }
+            }
+            """
+        } else {
+            // Generate ThrowingValue (read-write with getter and setter)
+            return """
+            \(raw: accessModifier)var \(raw: propertyName): \(raw: outerType) {
+                get {
+                    ThrowingValue(
+                        getter: \(raw: getterClosure),
+                        setter: \(raw: setterClosure)
+                    )
+                }
+            }
+            """
+        }
+    }
+    
+    private static func generateGetter(key: String, legacyKey: String?, type: String, baseType: String, isOptional: Bool, isBasicType: Bool, setupObservation: Bool = false, isThrowing: Bool = false) -> String {
+        let observationSetup = setupObservation ? "_setupAutoObservationIfNeeded()\n                " : ""
+        let keyLiteral = "\"\(key)\""
+        // Use try for throwing getters (ThrowingKeyValueStoring), no try for non-throwing
+        let tryKeyword = isThrowing ? "try " : ""
+        
+        // For basic types, use direct casting
+        if isBasicType {
+            guard let legacyKey = legacyKey else {
+                return "\(observationSetup)return \(tryKeyword)self.object(forKey: \(keyLiteral)) as? \(baseType)"
+            }
+            
+            let legacyKeyLiteral = "\"\(legacyKey)\""
+            return """
+\(observationSetup)if let value = \(tryKeyword)self.object(forKey: \(keyLiteral)) as? \(baseType) {
+                    return value
+                }
+                // Migrate from legacy key if present
+                if let legacyValue = \(tryKeyword)self.object(forKey: \(legacyKeyLiteral)) as? \(baseType) {
+                    \(tryKeyword)self.set(legacyValue, forKey: \(keyLiteral))
+                    \(tryKeyword)self.removeObject(forKey: \(legacyKeyLiteral))
+                    return legacyValue
+                }
+                return nil
+"""
+        }
+        
+        // For RawRepresentable types, try to get raw value and convert
+        guard let legacyKey = legacyKey else {
+            return """
+\(observationSetup)if let rawValue = \(tryKeyword)self.object(forKey: \(keyLiteral)) {
+                    return (rawValue as? \(baseType)) ?? (rawValue as? \(baseType).RawValue).flatMap(\(baseType).init(rawValue:))
+                }
+                return nil
+"""
+        }
+        
+        let legacyKeyLiteral = "\"\(legacyKey)\""
+        return """
+\(observationSetup)if let rawValue = \(tryKeyword)self.object(forKey: \(keyLiteral)) {
+                    if let value = rawValue as? \(baseType) {
+                        return value
+                    }
+                    if let value = (rawValue as? \(baseType).RawValue).flatMap(\(baseType).init(rawValue:)) {
+                        return value
+                    }
+                }
+                // Migrate from legacy key if present
+                if let legacyRawValue = \(tryKeyword)self.object(forKey: \(legacyKeyLiteral)) {
+                    let legacyValue = (legacyRawValue as? \(baseType)) ?? (legacyRawValue as? \(baseType).RawValue).flatMap(\(baseType).init(rawValue:))
+                    if let legacyValue = legacyValue {
+                        // Store the raw value, not the enum itself
+                        if let rawValue = (legacyValue as? any RawRepresentable)?.rawValue {
+                            \(tryKeyword)self.set(rawValue, forKey: \(keyLiteral))
+                        } else {
+                            \(tryKeyword)self.set(legacyValue, forKey: \(keyLiteral))
+                        }
+                        \(tryKeyword)self.removeObject(forKey: \(legacyKeyLiteral))
+                        return legacyValue
+                    }
+                }
+                return nil
+"""
+    }
+    
+    private static func generateSetter(key: String, legacyKey: String?, type: String, baseType: String, isOptional: Bool, isBasicType: Bool, isThrowing: Bool, setupObservation: Bool = false) -> String {
+        let keyLiteral = "\"\(key)\""
+        // Use try? for throwing operations to handle errors silently (properties can't throw)
+        let tryKeyword = isThrowing ? "try? " : ""
+        
+        // All non-ThrowingValue properties are optional, so we always unwrap
+        var code: String
+        
+        if isBasicType {
+            // For basic types, unwrap and set or remove
+            code = """
+if let newValue = newValue {
+                    \(tryKeyword)self.set(newValue, forKey: \(keyLiteral))
+                } else {
+                    \(tryKeyword)self.removeObject(forKey: \(keyLiteral))
+                }
+"""
+        } else {
+            // For RawRepresentable types, extract raw value if possible
+            code = """
+if let newValue = newValue {
+                    if let rawValue = (newValue as? any RawRepresentable)?.rawValue {
+                        \(tryKeyword)self.set(rawValue, forKey: \(keyLiteral))
+                    } else {
+                        \(tryKeyword)self.set(newValue, forKey: \(keyLiteral))
+                    }
+                } else {
+                    \(tryKeyword)self.removeObject(forKey: \(keyLiteral))
+                }
+"""
+        }
+        
+        // If legacy key exists, also remove it during migration
+        if let legacyKey = legacyKey {
+            let legacyKeyLiteral = "\"\(legacyKey)\""
+            code += "\n                \(tryKeyword)self.removeObject(forKey: \(legacyKeyLiteral))"
+        }
+        
+        return code
+    }
+}
+

--- a/Tests/MacrosTests/NestedObservableMacroTests.swift
+++ b/Tests/MacrosTests/NestedObservableMacroTests.swift
@@ -1,0 +1,214 @@
+//
+//  NestedObservableMacroTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@testable import MacrosImplementation
+import MacroTesting
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import Testing
+
+@Suite(
+  .macros(
+    [
+        "NestedObservable": NestedObservableMacro.self,
+    ],
+    record: .missing
+  )
+)
+struct NestedObservableMacroTests {
+    
+    @Test("Basic nested observable property")
+    func testBasicNestedObservableProperty() {
+        assertMacro {
+            """
+            final class ParentModel: ObservableObject {
+                @NestedObservable var child: ChildModel = ChildModel()
+            }
+            """
+        } expansion: {
+            """
+            final class ParentModel: ObservableObject {
+                var child: ChildModel = ChildModel() {
+                    get {
+                        if _childCancellable == nil {
+                            _childCancellable = _child.objectWillChange.sink { [weak self] _ in
+                                self?.objectWillChange.send()
+                            }
+                        }
+                        return _child
+                    }
+                    set {
+                        _childCancellable?.cancel()
+                        _child = newValue
+                        _childCancellable = _child.objectWillChange.sink { [weak self] _ in
+                            self?.objectWillChange.send()
+                        }
+                        objectWillChange.send()
+                    }
+                }
+
+                private var _child: ChildModel = ChildModel()
+
+                private var _childCancellable: AnyCancellable?
+            }
+            """
+        }
+    }
+    
+    @Test("Nested observable without initial value")
+    func testNestedObservableWithoutInitialValue() {
+        assertMacro {
+            """
+            final class ParentModel: ObservableObject {
+                @NestedObservable var child: ChildModel
+            }
+            """
+        } expansion: {
+            """
+            final class ParentModel: ObservableObject {
+                var child: ChildModel {
+                    get {
+                        if _childCancellable == nil {
+                            _childCancellable = _child.objectWillChange.sink { [weak self] _ in
+                                self?.objectWillChange.send()
+                            }
+                        }
+                        return _child
+                    }
+                    set {
+                        _childCancellable?.cancel()
+                        _child = newValue
+                        _childCancellable = _child.objectWillChange.sink { [weak self] _ in
+                            self?.objectWillChange.send()
+                        }
+                        objectWillChange.send()
+                    }
+                }
+
+                private var _child: ChildModel
+
+                private var _childCancellable: AnyCancellable?
+            }
+            """
+        }
+    }
+    
+    @Test("Multiple nested observable properties")
+    func testMultipleNestedObservableProperties() {
+        assertMacro {
+            """
+            final class ParentModel: ObservableObject {
+                @NestedObservable var child1: ChildModel = ChildModel()
+                @NestedObservable var child2: OtherModel = OtherModel()
+            }
+            """
+        } expansion: {
+            """
+            final class ParentModel: ObservableObject {
+                var child1: ChildModel = ChildModel() {
+                    get {
+                        if _child1Cancellable == nil {
+                            _child1Cancellable = _child1.objectWillChange.sink { [weak self] _ in
+                                self?.objectWillChange.send()
+                            }
+                        }
+                        return _child1
+                    }
+                    set {
+                        _child1Cancellable?.cancel()
+                        _child1 = newValue
+                        _child1Cancellable = _child1.objectWillChange.sink { [weak self] _ in
+                            self?.objectWillChange.send()
+                        }
+                        objectWillChange.send()
+                    }
+                }
+
+                private var _child1: ChildModel = ChildModel()
+
+                private var _child1Cancellable: AnyCancellable?
+                var child2: OtherModel = OtherModel() {
+                    get {
+                        if _child2Cancellable == nil {
+                            _child2Cancellable = _child2.objectWillChange.sink { [weak self] _ in
+                                self?.objectWillChange.send()
+                            }
+                        }
+                        return _child2
+                    }
+                    set {
+                        _child2Cancellable?.cancel()
+                        _child2 = newValue
+                        _child2Cancellable = _child2.objectWillChange.sink { [weak self] _ in
+                            self?.objectWillChange.send()
+                        }
+                        objectWillChange.send()
+                    }
+                }
+
+                private var _child2: OtherModel = OtherModel()
+
+                private var _child2Cancellable: AnyCancellable?
+            }
+            """
+        }
+    }
+    
+    @Test("Error on computed property")
+    func testErrorOnComputedProperty() {
+        assertMacro {
+            """
+            final class ParentModel: ObservableObject {
+                @NestedObservable var child: ChildModel {
+                    return ChildModel()
+                }
+            }
+            """
+        } diagnostics: {
+            """
+            final class ParentModel: ObservableObject {
+                @NestedObservable var child: ChildModel {
+                ┬────────────────
+                ╰─ 🛑 @NestedObservable cannot be applied to computed properties
+                    return ChildModel()
+                }
+            }
+            """
+        }
+    }
+    
+    @Test("Error without type annotation")
+    func testErrorWithoutTypeAnnotation() {
+        assertMacro {
+            """
+            final class ParentModel: ObservableObject {
+                @NestedObservable var child = ChildModel()
+            }
+            """
+        } diagnostics: {
+            """
+            final class ParentModel: ObservableObject {
+                @NestedObservable var child = ChildModel()
+                ┬────────────────
+                ╰─ 🛑 @NestedObservable can only be applied to variable declarations with explicit type annotations
+            }
+            """
+        }
+    }
+}
+

--- a/Tests/MacrosTests/StorageMacroTests.swift
+++ b/Tests/MacrosTests/StorageMacroTests.swift
@@ -1,0 +1,3531 @@
+//
+//  StorageMacroTests.swift
+//
+//  Copyright © 2025 DuckDuckGo. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+@testable import MacrosImplementation
+import MacroTesting
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import Testing
+
+@Suite(
+  .macros(
+    [
+        "Storage": StorageMacro.self,
+        "Key": KeyMacro.self,
+        "StorageIgnored": StorageIgnoredMacro.self
+    ],
+    record: .none
+  )
+)
+struct StorageMacroTests {
+    
+    // MARK: - Basic Expansion Tests
+    
+    @Test("Basic protocol with simple properties")
+    func testBasicProtocolWithSimpleProperties() {
+        assertMacro {
+            """
+            @Storage
+            protocol AppSettings: KeyValueStoring {
+                var isFirstLaunch: Bool? { get set }
+                var refreshInterval: Double? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol AppSettings: KeyValueStoring {
+              var isFirstLaunch: Bool? { get set }
+              var refreshInterval: Double? { get set }
+          }
+
+          private enum AppSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \AppSettings.isFirstLaunch: "isFirstLaunch",
+                  \AppSettings.refreshInterval: "refreshInterval"
+              ]
+          }
+
+          extension AppSettings {
+              var isFirstLaunch: Bool? {
+                  get {
+                      return self.object(forKey: "isFirstLaunch") as? Bool
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "isFirstLaunch")
+                              } else {
+                                  self.removeObject(forKey: "isFirstLaunch")
+                              }
+                  }
+              }
+              var refreshInterval: Double? {
+                  get {
+                      return self.object(forKey: "refreshInterval") as? Double
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "refreshInterval")
+                              } else {
+                                  self.removeObject(forKey: "refreshInterval")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Protocol with custom storage keys")
+    func testProtocolWithCustomStorageKeys() {
+        assertMacro {
+            """
+            @Storage
+            protocol AppSettings: KeyValueStoring {
+                @Key("is-first-launch")
+                var isFirstLaunch: Bool? { get set }
+                
+                var refreshInterval: Double? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol AppSettings: KeyValueStoring {
+              var isFirstLaunch: Bool? { get set 
+                  get {
+                      object(forKey: "is-first-launch") as? Bool
+                  }
+
+                  set {
+                      if let value = newValue {
+                                  set(value, forKey: "is-first-launch")
+                              } else {
+                                  removeObject(forKey: "is-first-launch")
+                              }
+                  }}
+              
+              var refreshInterval: Double? { get set }
+          }
+
+          private enum AppSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \AppSettings.isFirstLaunch: "is-first-launch",
+                  \AppSettings.refreshInterval: "refreshInterval"
+              ]
+          }
+
+          extension AppSettings {
+              var isFirstLaunch: Bool? {
+                  get {
+                      return self.object(forKey: "is-first-launch") as? Bool
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "is-first-launch")
+                              } else {
+                                  self.removeObject(forKey: "is-first-launch")
+                              }
+                  }
+              }
+              var refreshInterval: Double? {
+                  get {
+                      return self.object(forKey: "refreshInterval") as? Double
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "refreshInterval")
+                              } else {
+                                  self.removeObject(forKey: "refreshInterval")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Nested protocol in struct")
+    func testNestedProtocolInStruct() {
+        // Note: In real usage, the qualified name is correctly provided (e.g., SyncDiagnosisHelper.Settings).
+        // The helper enum name includes dots and becomes SyncDiagnosisHelper.SettingsKeyPathMapping.
+        assertMacro {
+            """
+            struct AppConfig {
+                @Storage
+                protocol Settings: KeyValueStoring {
+                    var debugMode: Bool? { get set }
+                    var apiKey: String? { get set }
+                }
+            }
+            """
+        } expansion: {
+          #"""
+          struct AppConfig {
+              protocol Settings: KeyValueStoring {
+                  var debugMode: Bool? { get set }
+                  var apiKey: String? { get set }
+              }
+
+              private enum SettingsKeyPathMapping {
+                  static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                      \Settings.debugMode: "debugMode",
+                      \Settings.apiKey: "apiKey"
+                  ]
+              }
+          }
+
+          extension Settings {
+              var debugMode: Bool? {
+                  get {
+                      return self.object(forKey: "debugMode") as? Bool
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "debugMode")
+                              } else {
+                                  self.removeObject(forKey: "debugMode")
+                              }
+                  }
+              }
+              var apiKey: String? {
+                  get {
+                      return self.object(forKey: "apiKey") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "apiKey")
+                              } else {
+                                  self.removeObject(forKey: "apiKey")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Optional types")
+    func testOptionalTypes() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var optionalBool: Bool? { get set }
+                var optionalInt: Int? { get set }
+                var optionalDouble: Double? { get set }
+                var optionalString: String? { get set }
+                var optionalData: Data? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol Settings: KeyValueStoring {
+              var optionalBool: Bool? { get set }
+              var optionalInt: Int? { get set }
+              var optionalDouble: Double? { get set }
+              var optionalString: String? { get set }
+              var optionalData: Data? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.optionalBool: "optionalBool",
+                  \Settings.optionalInt: "optionalInt",
+                  \Settings.optionalDouble: "optionalDouble",
+                  \Settings.optionalString: "optionalString",
+                  \Settings.optionalData: "optionalData"
+              ]
+          }
+
+          extension Settings {
+              var optionalBool: Bool? {
+                  get {
+                      return self.object(forKey: "optionalBool") as? Bool
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "optionalBool")
+                              } else {
+                                  self.removeObject(forKey: "optionalBool")
+                              }
+                  }
+              }
+              var optionalInt: Int? {
+                  get {
+                      return self.object(forKey: "optionalInt") as? Int
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "optionalInt")
+                              } else {
+                                  self.removeObject(forKey: "optionalInt")
+                              }
+                  }
+              }
+              var optionalDouble: Double? {
+                  get {
+                      return self.object(forKey: "optionalDouble") as? Double
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "optionalDouble")
+                              } else {
+                                  self.removeObject(forKey: "optionalDouble")
+                              }
+                  }
+              }
+              var optionalString: String? {
+                  get {
+                      return self.object(forKey: "optionalString") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "optionalString")
+                              } else {
+                                  self.removeObject(forKey: "optionalString")
+                              }
+                  }
+              }
+              var optionalData: Data? {
+                  get {
+                      return self.object(forKey: "optionalData") as? Data
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "optionalData")
+                              } else {
+                                  self.removeObject(forKey: "optionalData")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Non-optional types are rejected")
+    func testNonOptionalTypes() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var requiredBool: Bool { get set }
+                var requiredInt: Int { get set }
+                var requiredDouble: Double { get set }
+                var requiredString: String { get set }
+                var requiredData: Data { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage property 'requiredBool' must be optional. Change 'Bool' to 'Bool?'. Only ThrowingValue<T> and ThrowingGetter<T> properties can be non-optional.
+          protocol Settings: KeyValueStoring {
+              var requiredBool: Bool { get set }
+              var requiredInt: Int { get set }
+              var requiredDouble: Double { get set }
+              var requiredString: String { get set }
+              var requiredData: Data { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Mixed optional and non-optional properties")
+    func testMixedOptionalAndNonOptional() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var isEnabled: Bool { get set }
+                var username: String? { get set }
+                var count: Int { get set }
+                var lastSync: Double? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage property 'isEnabled' must be optional. Change 'Bool' to 'Bool?'. Only ThrowingValue<T> and ThrowingGetter<T> properties can be non-optional.
+          protocol Settings: KeyValueStoring {
+              var isEnabled: Bool { get set }
+              var username: String? { get set }
+              var count: Int { get set }
+              var lastSync: Double? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Empty protocol")
+    func testEmptyProtocol() {
+        assertMacro {
+            """
+            @Storage
+            protocol EmptySettings: KeyValueStoring {
+            }
+            """
+        } expansion: {
+          """
+          protocol EmptySettings: KeyValueStoring {
+          }
+
+          private enum EmptySettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+
+              ]
+          }
+
+          extension EmptySettings {
+          }
+          """
+        }
+    }
+    
+    @Test("Protocol with read-only properties")
+    func testProtocolWithReadOnlyProperties() {
+        assertMacro {
+            """
+            @Storage
+            protocol ReadOnlySettings: KeyValueStoring {
+                var value: String { get }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage property 'value' must be optional. Change 'String' to 'String?'. Only ThrowingValue<T> and ThrowingGetter<T> properties can be non-optional.
+          protocol ReadOnlySettings: KeyValueStoring {
+              var value: String { get }
+          }
+          """
+        }
+    }
+    
+    @Test("Protocol not inheriting from KeyValueStoring")
+    func testProtocolNotInheritingFromKeyValueStoring() {
+        assertMacro {
+            """
+            @Storage
+            protocol BadSettings {
+                var value: String? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage requires the protocol to inherit from exactly one of: KeyValueStoring, ThrowingKeyValueStoring, ObservableKeyValueStoring, or ObservableThrowingKeyValueStoring
+          protocol BadSettings {
+              var value: String? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Complex types")
+    func testComplexTypes() {
+        assertMacro {
+            """
+            @Storage
+            protocol ComplexSettings: KeyValueStoring {
+                var array: [String]? { get set }
+                var dictionary: [String: Int]? { get set }
+                var date: Date? { get set }
+                var url: URL? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol ComplexSettings: KeyValueStoring {
+              var array: [String]? { get set }
+              var dictionary: [String: Int]? { get set }
+              var date: Date? { get set }
+              var url: URL? { get set }
+          }
+
+          private enum ComplexSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ComplexSettings.array: "array",
+                  \ComplexSettings.dictionary: "dictionary",
+                  \ComplexSettings.date: "date",
+                  \ComplexSettings.url: "url"
+              ]
+          }
+
+          extension ComplexSettings {
+              var array: [String]? {
+                  get {
+                      return self.object(forKey: "array") as? [String]
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "array")
+                              } else {
+                                  self.removeObject(forKey: "array")
+                              }
+                  }
+              }
+              var dictionary: [String: Int]? {
+                  get {
+                      return self.object(forKey: "dictionary") as? [String: Int]
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "dictionary")
+                              } else {
+                                  self.removeObject(forKey: "dictionary")
+                              }
+                  }
+              }
+              var date: Date? {
+                  get {
+                      return self.object(forKey: "date") as? Date
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "date")
+                              } else {
+                                  self.removeObject(forKey: "date")
+                              }
+                  }
+              }
+              var url: URL? {
+                  get {
+                      return self.object(forKey: "url") as? URL
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "url")
+                              } else {
+                                  self.removeObject(forKey: "url")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Multiple StorageKey attributes")
+    func testMultipleStorageKeyAttributes() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                @Key("app.first.launch")
+                var isFirstLaunch: Bool? { get set }
+                
+                @Key("user.name")
+                var userName: String? { get set }
+                
+                @Key("session.count")
+                var sessionCount: Int? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          protocol Settings: KeyValueStoring {
+              @Key("app.first.launch")
+              ┬───────────────────────
+              ╰─ 🛑 @Key error: The key 'app.first.launch' contains a dot (.) which breaks KVO observation.
+
+          Keys with dots cannot be observed by ObservableKeyValueStoring protocols.
+
+          Choose one of these solutions:
+
+          1. Migrate to a new key without dots (recommended):
+             @Key("newKeyWithoutDots", migratingLegacyKey: "app.first.launch")
+
+          2. If this key will NOT be observed (not used with ObservableKeyValueStoring):
+             @Key("app.first.launch", allowDotsForLegacyKey: true)
+              var isFirstLaunch: Bool? { get set }
+              
+              @Key("user.name")
+              ┬────────────────
+              ╰─ 🛑 @Key error: The key 'user.name' contains a dot (.) which breaks KVO observation.
+
+          Keys with dots cannot be observed by ObservableKeyValueStoring protocols.
+
+          Choose one of these solutions:
+
+          1. Migrate to a new key without dots (recommended):
+             @Key("newKeyWithoutDots", migratingLegacyKey: "user.name")
+
+          2. If this key will NOT be observed (not used with ObservableKeyValueStoring):
+             @Key("user.name", allowDotsForLegacyKey: true)
+              var userName: String? { get set }
+              
+              @Key("session.count")
+              ┬────────────────────
+              ╰─ 🛑 @Key error: The key 'session.count' contains a dot (.) which breaks KVO observation.
+
+          Keys with dots cannot be observed by ObservableKeyValueStoring protocols.
+
+          Choose one of these solutions:
+
+          1. Migrate to a new key without dots (recommended):
+             @Key("newKeyWithoutDots", migratingLegacyKey: "session.count")
+
+          2. If this key will NOT be observed (not used with ObservableKeyValueStoring):
+             @Key("session.count", allowDotsForLegacyKey: true)
+              var sessionCount: Int? { get set }
+          }
+          """
+        } 
+    }
+    
+    @Test("Single non-optional property")
+    func testSingleNonOptionalProperty() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var isEnabled: Bool { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage property 'isEnabled' must be optional. Change 'Bool' to 'Bool?'. Only ThrowingValue<T> and ThrowingGetter<T> properties can be non-optional.
+          protocol Settings: KeyValueStoring {
+              var isEnabled: Bool { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Unsupported custom type")
+    func testUnsupportedCustomType() {
+        assertMacro {
+            """
+            struct CustomType {
+                var value: String
+            }
+            
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var customValue: CustomType? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          struct CustomType {
+              var value: String
+          }
+          protocol Settings: KeyValueStoring {
+              var customValue: CustomType? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.customValue: "customValue"
+              ]
+          }
+
+          extension Settings {
+              var customValue: CustomType? {
+                  get {
+                      if let rawValue = self.object(forKey: "customValue") {
+                                  return (rawValue as? CustomType) ?? (rawValue as? CustomType.RawValue).flatMap(CustomType.init(rawValue:))
+                              }
+                              return nil
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  if let rawValue = (newValue as? any RawRepresentable)?.rawValue {
+                                      self.set(rawValue, forKey: "customValue")
+                                  } else {
+                                      self.set(newValue, forKey: "customValue")
+                                  }
+                              } else {
+                                  self.removeObject(forKey: "customValue")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Unsupported tuple type")
+    func testUnsupportedTupleType() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var coordinates: (Double, Double)? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage does not support tuple type '(Double, Double)' for property 'coordinates'. Use @StorageIgnored to exclude this property.
+          protocol Settings: KeyValueStoring {
+              var coordinates: (Double, Double)? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Unsupported closure type")
+    func testUnsupportedClosureType() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var callback: (() -> Void)? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage does not support closure type '(() -> Void)' for property 'callback'. Use @StorageIgnored to exclude this property.
+          protocol Settings: KeyValueStoring {
+              var callback: (() -> Void)? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Mixed supported and unsupported types - unsupported types pass through macro but fail at compile-time")
+    func testMixedSupportedAndUnsupportedTypes() {
+        // Note: The macro generates code for CustomType (treating it as potentially RawRepresentable),
+        // but this will fail at Swift compile-time since CustomType doesn't conform to RawRepresentable
+        // and can't be stored in UserDefaults. This is intentional - we let Swift's type system catch it.
+        assertMacro {
+            """
+            struct CustomType {
+                var value: String
+            }
+            
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var validString: String? { get set }
+                var invalidCustom: CustomType? { get set }
+                var validInt: Int? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          struct CustomType {
+              var value: String
+          }
+          protocol Settings: KeyValueStoring {
+              var validString: String? { get set }
+              var invalidCustom: CustomType? { get set }
+              var validInt: Int? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.validString: "validString",
+                  \Settings.invalidCustom: "invalidCustom",
+                  \Settings.validInt: "validInt"
+              ]
+          }
+
+          extension Settings {
+              var validString: String? {
+                  get {
+                      return self.object(forKey: "validString") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "validString")
+                              } else {
+                                  self.removeObject(forKey: "validString")
+                              }
+                  }
+              }
+              var invalidCustom: CustomType? {
+                  get {
+                      if let rawValue = self.object(forKey: "invalidCustom") {
+                                  return (rawValue as? CustomType) ?? (rawValue as? CustomType.RawValue).flatMap(CustomType.init(rawValue:))
+                              }
+                              return nil
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  if let rawValue = (newValue as? any RawRepresentable)?.rawValue {
+                                      self.set(rawValue, forKey: "invalidCustom")
+                                  } else {
+                                      self.set(newValue, forKey: "invalidCustom")
+                                  }
+                              } else {
+                                  self.removeObject(forKey: "invalidCustom")
+                              }
+                  }
+              }
+              var validInt: Int? {
+                  get {
+                      return self.object(forKey: "validInt") as? Int
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "validInt")
+                              } else {
+                                  self.removeObject(forKey: "validInt")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Data type is supported")
+    func testDataTypeSupported() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var imageData: Data? { get set }
+                var configData: Data? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol Settings: KeyValueStoring {
+              var imageData: Data? { get set }
+              var configData: Data? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.imageData: "imageData",
+                  \Settings.configData: "configData"
+              ]
+          }
+
+          extension Settings {
+              var imageData: Data? {
+                  get {
+                      return self.object(forKey: "imageData") as? Data
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "imageData")
+                              } else {
+                                  self.removeObject(forKey: "imageData")
+                              }
+                  }
+              }
+              var configData: Data? {
+                  get {
+                      return self.object(forKey: "configData") as? Data
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "configData")
+                              } else {
+                                  self.removeObject(forKey: "configData")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Custom class type passes through macro but fails at compile-time")
+    func testCustomClassTypePassesThrough() {
+        // Note: The macro generates code for CustomClass (treating it as potentially RawRepresentable),
+        // but this will fail at Swift compile-time since classes can't be stored in UserDefaults.
+        assertMacro {
+            """
+            class CustomClass {
+                var value: String
+            }
+            
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var customObject: CustomClass? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          class CustomClass {
+              var value: String
+          }
+          protocol Settings: KeyValueStoring {
+              var customObject: CustomClass? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.customObject: "customObject"
+              ]
+          }
+
+          extension Settings {
+              var customObject: CustomClass? {
+                  get {
+                      if let rawValue = self.object(forKey: "customObject") {
+                                  return (rawValue as? CustomClass) ?? (rawValue as? CustomClass.RawValue).flatMap(CustomClass.init(rawValue:))
+                              }
+                              return nil
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  if let rawValue = (newValue as? any RawRepresentable)?.rawValue {
+                                      self.set(rawValue, forKey: "customObject")
+                                  } else {
+                                      self.set(newValue, forKey: "customObject")
+                                  }
+                              } else {
+                                  self.removeObject(forKey: "customObject")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Custom enum without RawRepresentable passes through macro but fails at compile-time")
+    func testCustomEnumWithoutRawValuePassesThrough() {
+        // Note: The macro generates code for CustomEnum (treating it as potentially RawRepresentable),
+        // but this will fail at Swift compile-time since CustomEnum has no raw value.
+        // Enums MUST have String or Int raw values to work with UserDefaults.
+        assertMacro {
+            """
+            enum CustomEnum {
+                case one, two
+            }
+            
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var enumValue: CustomEnum? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          enum CustomEnum {
+              case one, two
+          }
+          protocol Settings: KeyValueStoring {
+              var enumValue: CustomEnum? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.enumValue: "enumValue"
+              ]
+          }
+
+          extension Settings {
+              var enumValue: CustomEnum? {
+                  get {
+                      if let rawValue = self.object(forKey: "enumValue") {
+                                  return (rawValue as? CustomEnum) ?? (rawValue as? CustomEnum.RawValue).flatMap(CustomEnum.init(rawValue:))
+                              }
+                              return nil
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  if let rawValue = (newValue as? any RawRepresentable)?.rawValue {
+                                      self.set(rawValue, forKey: "enumValue")
+                                  } else {
+                                      self.set(newValue, forKey: "enumValue")
+                                  }
+                              } else {
+                                  self.removeObject(forKey: "enumValue")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Protocol with functions ignores them")
+    func testProtocolWithFunctionsIgnoresThem() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var value: String? { get set }
+                func doSomething()
+                func getValue() -> String?
+            }
+            """
+        } expansion: {
+          #"""
+          protocol Settings: KeyValueStoring {
+              var value: String? { get set }
+              func doSomething()
+              func getValue() -> String?
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.value: "value"
+              ]
+          }
+
+          extension Settings {
+              var value: String? {
+                  get {
+                      return self.object(forKey: "value") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "value")
+                              } else {
+                                  self.removeObject(forKey: "value")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Protocol with associated types ignores them")
+    func testProtocolWithAssociatedTypesIgnoresThem() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                associatedtype ValueType
+                var value: String? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol Settings: KeyValueStoring {
+              associatedtype ValueType
+              var value: String? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.value: "value"
+              ]
+          }
+
+          extension Settings {
+              var value: String? {
+                  get {
+                      return self.object(forKey: "value") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "value")
+                              } else {
+                                  self.removeObject(forKey: "value")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Protocol without KeyValueStoring inheritance")
+    func testProtocolWithoutKeyValueStoringShowsWarning() {
+        assertMacro {
+            """
+            @Storage
+            protocol BadSettings {
+                var value: String? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage requires the protocol to inherit from exactly one of: KeyValueStoring, ThrowingKeyValueStoring, ObservableKeyValueStoring, or ObservableThrowingKeyValueStoring
+          protocol BadSettings {
+              var value: String? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Protocol with ThrowingKeyValueStoring works")
+    func testProtocolWithThrowingKeyValueStoring() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: ThrowingKeyValueStoring {
+                var value: String? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage with ThrowingKeyValueStoring requires properties to use ThrowingValue<T> or ThrowingGetter<T>. Property 'value' has type 'String?'. Use 'var value: ThrowingValue<String> { get }' for read-write or 'var value: ThrowingGetter<String> { get }' for read-only.
+          protocol Settings: ThrowingKeyValueStoring {
+              var value: String? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Protocol with both storage protocols works")
+    func testProtocolWithBothStorageProtocols() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring, ThrowingKeyValueStoring {
+                var value: String? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage protocol cannot inherit from multiple storage protocols. Found: KeyValueStoring, ThrowingKeyValueStoring. Choose exactly one.
+          protocol Settings: KeyValueStoring, ThrowingKeyValueStoring {
+              var value: String? { get set }
+          }
+          """
+        } 
+    }
+    
+    @Test("All UserDefaults-supported types")
+    func testAllUserDefaultsSupportedTypes() {
+        assertMacro {
+            """
+            @Storage
+            protocol AllTypes: KeyValueStoring {
+                var boolValue: Bool? { get set }
+                var intValue: Int? { get set }
+                var doubleValue: Double? { get set }
+                var floatValue: Float? { get set }
+                var stringValue: String? { get set }
+                var dataValue: Data? { get set }
+                var dateValue: Date? { get set }
+                var urlValue: URL? { get set }
+                var arrayValue: [String]? { get set }
+                var dictValue: [String: Int]? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol AllTypes: KeyValueStoring {
+              var boolValue: Bool? { get set }
+              var intValue: Int? { get set }
+              var doubleValue: Double? { get set }
+              var floatValue: Float? { get set }
+              var stringValue: String? { get set }
+              var dataValue: Data? { get set }
+              var dateValue: Date? { get set }
+              var urlValue: URL? { get set }
+              var arrayValue: [String]? { get set }
+              var dictValue: [String: Int]? { get set }
+          }
+
+          private enum AllTypesKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \AllTypes.boolValue: "boolValue",
+                  \AllTypes.intValue: "intValue",
+                  \AllTypes.doubleValue: "doubleValue",
+                  \AllTypes.floatValue: "floatValue",
+                  \AllTypes.stringValue: "stringValue",
+                  \AllTypes.dataValue: "dataValue",
+                  \AllTypes.dateValue: "dateValue",
+                  \AllTypes.urlValue: "urlValue",
+                  \AllTypes.arrayValue: "arrayValue",
+                  \AllTypes.dictValue: "dictValue"
+              ]
+          }
+
+          extension AllTypes {
+              var boolValue: Bool? {
+                  get {
+                      return self.object(forKey: "boolValue") as? Bool
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "boolValue")
+                              } else {
+                                  self.removeObject(forKey: "boolValue")
+                              }
+                  }
+              }
+              var intValue: Int? {
+                  get {
+                      return self.object(forKey: "intValue") as? Int
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "intValue")
+                              } else {
+                                  self.removeObject(forKey: "intValue")
+                              }
+                  }
+              }
+              var doubleValue: Double? {
+                  get {
+                      return self.object(forKey: "doubleValue") as? Double
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "doubleValue")
+                              } else {
+                                  self.removeObject(forKey: "doubleValue")
+                              }
+                  }
+              }
+              var floatValue: Float? {
+                  get {
+                      return self.object(forKey: "floatValue") as? Float
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "floatValue")
+                              } else {
+                                  self.removeObject(forKey: "floatValue")
+                              }
+                  }
+              }
+              var stringValue: String? {
+                  get {
+                      return self.object(forKey: "stringValue") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "stringValue")
+                              } else {
+                                  self.removeObject(forKey: "stringValue")
+                              }
+                  }
+              }
+              var dataValue: Data? {
+                  get {
+                      return self.object(forKey: "dataValue") as? Data
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "dataValue")
+                              } else {
+                                  self.removeObject(forKey: "dataValue")
+                              }
+                  }
+              }
+              var dateValue: Date? {
+                  get {
+                      return self.object(forKey: "dateValue") as? Date
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "dateValue")
+                              } else {
+                                  self.removeObject(forKey: "dateValue")
+                              }
+                  }
+              }
+              var urlValue: URL? {
+                  get {
+                      return self.object(forKey: "urlValue") as? URL
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "urlValue")
+                              } else {
+                                  self.removeObject(forKey: "urlValue")
+                              }
+                  }
+              }
+              var arrayValue: [String]? {
+                  get {
+                      return self.object(forKey: "arrayValue") as? [String]
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "arrayValue")
+                              } else {
+                                  self.removeObject(forKey: "arrayValue")
+                              }
+                  }
+              }
+              var dictValue: [String: Int]? {
+                  get {
+                      return self.object(forKey: "dictValue") as? [String: Int]
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "dictValue")
+                              } else {
+                                  self.removeObject(forKey: "dictValue")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    // MARK: - Legacy Key Migration Tests
+    
+    @Test("Property with legacy key generates migration code")
+    func testPropertyWithLegacyKey() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                @Key("new.key", legacyKey: "old.key")
+                var migratedProperty: String? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          protocol Settings: KeyValueStoring {
+              @Key("new.key", legacyKey: "old.key")
+              ┬────────────────────────────────────
+              ╰─ 🛑 @Key error: The key 'new.key' contains a dot (.) which breaks KVO observation.
+
+          Keys with dots cannot be observed by ObservableKeyValueStoring protocols.
+
+          Choose one of these solutions:
+
+          1. Migrate to a new key without dots (recommended):
+             @Key("newKeyWithoutDots", migratingLegacyKey: "new.key")
+
+          2. If this key will NOT be observed (not used with ObservableKeyValueStoring):
+             @Key("new.key", allowDotsForLegacyKey: true)
+              var migratedProperty: String? { get set }
+          }
+          """
+        } 
+    }
+    
+    @Test("Multiple properties with legacy keys")
+    func testMultiplePropertiesWithLegacyKeys() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                @Key("user.name", legacyKey: "username")
+                var userName: String? { get set }
+                
+                @Key("is.enabled", legacyKey: "enabled")
+                var isEnabled: Bool? { get set }
+                
+                var normalProperty: Int? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          protocol Settings: KeyValueStoring {
+              @Key("user.name", legacyKey: "username")
+              ┬───────────────────────────────────────
+              ╰─ 🛑 @Key error: The key 'user.name' contains a dot (.) which breaks KVO observation.
+
+          Keys with dots cannot be observed by ObservableKeyValueStoring protocols.
+
+          Choose one of these solutions:
+
+          1. Migrate to a new key without dots (recommended):
+             @Key("newKeyWithoutDots", migratingLegacyKey: "user.name")
+
+          2. If this key will NOT be observed (not used with ObservableKeyValueStoring):
+             @Key("user.name", allowDotsForLegacyKey: true)
+              var userName: String? { get set }
+              
+              @Key("is.enabled", legacyKey: "enabled")
+              ┬───────────────────────────────────────
+              ╰─ 🛑 @Key error: The key 'is.enabled' contains a dot (.) which breaks KVO observation.
+
+          Keys with dots cannot be observed by ObservableKeyValueStoring protocols.
+
+          Choose one of these solutions:
+
+          1. Migrate to a new key without dots (recommended):
+             @Key("newKeyWithoutDots", migratingLegacyKey: "is.enabled")
+
+          2. If this key will NOT be observed (not used with ObservableKeyValueStoring):
+             @Key("is.enabled", allowDotsForLegacyKey: true)
+              var isEnabled: Bool? { get set }
+              
+              var normalProperty: Int? { get set }
+          }
+          """
+        } 
+    }
+    
+    // MARK: - StorageIgnored Tests
+    
+    @Test("StorageIgnored on function prevents generation")
+    func testStorageIgnoredOnFunction() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var value: String? { get set }
+                
+                @StorageIgnored
+                func customMethod()
+                
+                @StorageIgnored
+                func anotherMethod() -> Int
+            }
+            """
+        } expansion: {
+          #"""
+          protocol Settings: KeyValueStoring {
+              var value: String? { get set }
+              
+              func customMethod()
+              
+              func anotherMethod() -> Int
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.value: "value"
+              ]
+          }
+
+          extension Settings {
+              var value: String? {
+                  get {
+                      return self.object(forKey: "value") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "value")
+                              } else {
+                                  self.removeObject(forKey: "value")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("StorageIgnored on associated type")
+    func testStorageIgnoredOnAssociatedType() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var value: String? { get set }
+                
+                @StorageIgnored
+                associatedtype ValueType
+            }
+            """
+        } expansion: {
+          #"""
+          protocol Settings: KeyValueStoring {
+              var value: String? { get set }
+              
+              associatedtype ValueType
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.value: "value"
+              ]
+          }
+
+          extension Settings {
+              var value: String? {
+                  get {
+                      return self.object(forKey: "value") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "value")
+                              } else {
+                                  self.removeObject(forKey: "value")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("StorageIgnored mixed with regular properties")
+    func testStorageIgnoredMixedWithProperties() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var prop1: String? { get set }
+                
+                @StorageIgnored
+                func helper()
+                
+                var prop2: Int? { get set }
+                
+                @StorageIgnored
+                associatedtype T
+                
+                var prop3: Bool? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol Settings: KeyValueStoring {
+              var prop1: String? { get set }
+              
+              func helper()
+              
+              var prop2: Int? { get set }
+              
+              associatedtype T
+              
+              var prop3: Bool? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.prop1: "prop1",
+                  \Settings.prop2: "prop2",
+                  \Settings.prop3: "prop3"
+              ]
+          }
+
+          extension Settings {
+              var prop1: String? {
+                  get {
+                      return self.object(forKey: "prop1") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "prop1")
+                              } else {
+                                  self.removeObject(forKey: "prop1")
+                              }
+                  }
+              }
+              var prop2: Int? {
+                  get {
+                      return self.object(forKey: "prop2") as? Int
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "prop2")
+                              } else {
+                                  self.removeObject(forKey: "prop2")
+                              }
+                  }
+              }
+              var prop3: Bool? {
+                  get {
+                      return self.object(forKey: "prop3") as? Bool
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "prop3")
+                              } else {
+                                  self.removeObject(forKey: "prop3")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    // MARK: - RawRepresentable Enum Tests
+    
+    @Test("Enum with String raw value")
+    func testEnumWithStringRawValue() {
+        assertMacro {
+            """
+            enum Theme: String {
+                case light, dark
+            }
+            
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var theme: Theme? { get set }
+                var name: String? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          enum Theme: String {
+              case light, dark
+          }
+          protocol Settings: KeyValueStoring {
+              var theme: Theme? { get set }
+              var name: String? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.theme: "theme",
+                  \Settings.name: "name"
+              ]
+          }
+
+          extension Settings {
+              var theme: Theme? {
+                  get {
+                      if let rawValue = self.object(forKey: "theme") {
+                                  return (rawValue as? Theme) ?? (rawValue as? Theme.RawValue).flatMap(Theme.init(rawValue:))
+                              }
+                              return nil
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  if let rawValue = (newValue as? any RawRepresentable)?.rawValue {
+                                      self.set(rawValue, forKey: "theme")
+                                  } else {
+                                      self.set(newValue, forKey: "theme")
+                                  }
+                              } else {
+                                  self.removeObject(forKey: "theme")
+                              }
+                  }
+              }
+              var name: String? {
+                  get {
+                      return self.object(forKey: "name") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "name")
+                              } else {
+                                  self.removeObject(forKey: "name")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Enum with Int raw value")
+    func testEnumWithIntRawValue() {
+        assertMacro {
+            """
+            enum Priority: Int {
+                case low = 0
+                case high = 1
+            }
+            
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var priority: Priority? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          enum Priority: Int {
+              case low = 0
+              case high = 1
+          }
+          protocol Settings: KeyValueStoring {
+              var priority: Priority? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.priority: "priority"
+              ]
+          }
+
+          extension Settings {
+              var priority: Priority? {
+                  get {
+                      if let rawValue = self.object(forKey: "priority") {
+                                  return (rawValue as? Priority) ?? (rawValue as? Priority.RawValue).flatMap(Priority.init(rawValue:))
+                              }
+                              return nil
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  if let rawValue = (newValue as? any RawRepresentable)?.rawValue {
+                                      self.set(rawValue, forKey: "priority")
+                                  } else {
+                                      self.set(newValue, forKey: "priority")
+                                  }
+                              } else {
+                                  self.removeObject(forKey: "priority")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Multiple enum properties")
+    func testMultipleEnumProperties() {
+        assertMacro {
+            """
+            enum TabPosition: String {
+                case top, bottom
+            }
+            
+            enum SortOrder: Int {
+                case ascending = 0
+                case descending = 1
+            }
+            
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var tabPosition: TabPosition? { get set }
+                var sortOrder: SortOrder? { get set }
+                var isEnabled: Bool? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          enum TabPosition: String {
+              case top, bottom
+          }
+
+          enum SortOrder: Int {
+              case ascending = 0
+              case descending = 1
+          }
+          protocol Settings: KeyValueStoring {
+              var tabPosition: TabPosition? { get set }
+              var sortOrder: SortOrder? { get set }
+              var isEnabled: Bool? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.tabPosition: "tabPosition",
+                  \Settings.sortOrder: "sortOrder",
+                  \Settings.isEnabled: "isEnabled"
+              ]
+          }
+
+          extension Settings {
+              var tabPosition: TabPosition? {
+                  get {
+                      if let rawValue = self.object(forKey: "tabPosition") {
+                                  return (rawValue as? TabPosition) ?? (rawValue as? TabPosition.RawValue).flatMap(TabPosition.init(rawValue:))
+                              }
+                              return nil
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  if let rawValue = (newValue as? any RawRepresentable)?.rawValue {
+                                      self.set(rawValue, forKey: "tabPosition")
+                                  } else {
+                                      self.set(newValue, forKey: "tabPosition")
+                                  }
+                              } else {
+                                  self.removeObject(forKey: "tabPosition")
+                              }
+                  }
+              }
+              var sortOrder: SortOrder? {
+                  get {
+                      if let rawValue = self.object(forKey: "sortOrder") {
+                                  return (rawValue as? SortOrder) ?? (rawValue as? SortOrder.RawValue).flatMap(SortOrder.init(rawValue:))
+                              }
+                              return nil
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  if let rawValue = (newValue as? any RawRepresentable)?.rawValue {
+                                      self.set(rawValue, forKey: "sortOrder")
+                                  } else {
+                                      self.set(newValue, forKey: "sortOrder")
+                                  }
+                              } else {
+                                  self.removeObject(forKey: "sortOrder")
+                              }
+                  }
+              }
+              var isEnabled: Bool? {
+                  get {
+                      return self.object(forKey: "isEnabled") as? Bool
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "isEnabled")
+                              } else {
+                                  self.removeObject(forKey: "isEnabled")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Enum with legacy key migration")
+    func testEnumWithLegacyKeyMigration() {
+        assertMacro {
+            """
+            enum DisplayMode: String {
+                case compact, expanded
+            }
+            
+            @Storage
+            protocol Settings: KeyValueStoring {
+                @Key("new.display.mode", legacyKey: "displayMode")
+                var displayMode: DisplayMode? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          enum DisplayMode: String {
+              case compact, expanded
+          }
+
+          @Storage
+          protocol Settings: KeyValueStoring {
+              @Key("new.display.mode", legacyKey: "displayMode")
+              ┬─────────────────────────────────────────────────
+              ╰─ 🛑 @Key error: The key 'new.display.mode' contains a dot (.) which breaks KVO observation.
+
+          Keys with dots cannot be observed by ObservableKeyValueStoring protocols.
+
+          Choose one of these solutions:
+
+          1. Migrate to a new key without dots (recommended):
+             @Key("newKeyWithoutDots", migratingLegacyKey: "new.display.mode")
+
+          2. If this key will NOT be observed (not used with ObservableKeyValueStoring):
+             @Key("new.display.mode", allowDotsForLegacyKey: true)
+              var displayMode: DisplayMode? { get set }
+          }
+          """
+        } 
+    }
+    
+    // MARK: - Protocol Inheritance Validation Tests
+    
+    @Test("Protocol without base protocol inheritance should fail")
+    func testProtocolWithoutBaseProtocolInheritance() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings {
+                var value: String? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage requires the protocol to inherit from exactly one of: KeyValueStoring, ThrowingKeyValueStoring, ObservableKeyValueStoring, or ObservableThrowingKeyValueStoring
+          protocol Settings {
+              var value: String? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Protocol with ThrowingKeyValueStoring inheritance")
+    func testThrowingKeyValueStoringProtocol() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: ThrowingKeyValueStoring {
+                var value: String? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage with ThrowingKeyValueStoring requires properties to use ThrowingValue<T> or ThrowingGetter<T>. Property 'value' has type 'String?'. Use 'var value: ThrowingValue<String> { get }' for read-write or 'var value: ThrowingGetter<String> { get }' for read-only.
+          protocol Settings: ThrowingKeyValueStoring {
+              var value: String? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Protocol with KeyValueStoring inheritance")
+    func testKeyValueStoringProtocol() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var value: String? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol Settings: KeyValueStoring {
+              var value: String? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.value: "value"
+              ]
+          }
+
+          extension Settings {
+              var value: String? {
+                  get {
+                      return self.object(forKey: "value") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "value")
+                              } else {
+                                  self.removeObject(forKey: "value")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    // MARK: - ThrowingValue Tests
+    
+    @Test("ThrowingKeyValueStoring with ThrowingValue properties")
+    func testThrowingValueBasic() {
+        assertMacro {
+            """
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                var username: ThrowingValue<String> { get }
+                var count: ThrowingValue<Int> { get }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var username: ThrowingValue<String> { get }
+              var count: ThrowingValue<Int> { get }
+          }
+
+          private enum ThrowingSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ThrowingSettings.username: "username",
+                  \ThrowingSettings.count: "count"
+              ]
+          }
+
+          extension ThrowingSettings {
+              var username: ThrowingValue<String> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "username") as? String
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "username")
+                  } else {
+                      try self.removeObject(forKey: "username")
+                  }
+                          }
+                      )
+                  }
+              }
+              var count: ThrowingValue<Int> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "count") as? Int
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "count")
+                  } else {
+                      try self.removeObject(forKey: "count")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("ThrowingValue with custom key")
+    func testThrowingValueWithCustomKey() {
+        assertMacro {
+            """
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                @Key("user_name")
+                var username: ThrowingValue<String> { get }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var username: ThrowingValue<String> { get }
+          }
+
+          private enum ThrowingSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ThrowingSettings.username: "user_name"
+              ]
+          }
+
+          extension ThrowingSettings {
+              var username: ThrowingValue<String> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "user_name") as? String
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "user_name")
+                  } else {
+                      try self.removeObject(forKey: "user_name")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("ThrowingValue with legacy key migration")
+    func testThrowingValueWithLegacyKey() {
+        assertMacro {
+            """
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                @Key("newUsername", migratingLegacyKey: "old.username")
+                var username: ThrowingValue<String> { get }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var username: ThrowingValue<String> { get }
+          }
+
+          private enum ThrowingSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ThrowingSettings.username: "newUsername"
+              ]
+          }
+
+          extension ThrowingSettings {
+              var username: ThrowingValue<String> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  if let value = try self.object(forKey: "newUsername") as? String {
+                      return value
+                  }
+                  // Migration: check legacy key
+                  if let legacyValue = try self.object(forKey: "old.username") as? String {
+                      try self.set(legacyValue, forKey: "newUsername")
+                      try self.removeObject(forKey: "old.username")
+                      return legacyValue
+                  }
+                  return nil
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "newUsername")
+                  } else {
+                      try self.removeObject(forKey: "newUsername")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("ThrowingValue with RawRepresentable enum")
+    func testThrowingValueWithEnum() {
+        assertMacro {
+            """
+            enum Theme: String {
+                case light, dark
+            }
+            
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                var theme: ThrowingValue<Theme> { get }
+            }
+            """
+        } expansion: {
+          #"""
+          enum Theme: String {
+              case light, dark
+          }
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var theme: ThrowingValue<Theme> { get }
+          }
+
+          private enum ThrowingSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ThrowingSettings.theme: "theme"
+              ]
+          }
+
+          extension ThrowingSettings {
+              var theme: ThrowingValue<Theme> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  guard let rawValue = try self.object(forKey: "theme") else {
+                      return nil
+                  }
+                  return (Theme)(rawValue: rawValue as! Theme.RawValue)
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      if let rawValue = (newValue as? any RawRepresentable)?.rawValue {
+                          try self.set(rawValue, forKey: "theme")
+                      } else {
+                          try self.set(newValue, forKey: "theme")
+                      }
+                  } else {
+                      try self.removeObject(forKey: "theme")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("ThrowingValue with enum and legacy key")
+    func testThrowingValueEnumWithLegacyKey() {
+        assertMacro {
+            """
+            enum DisplayMode: Int {
+                case compact = 0
+                case expanded = 1
+            }
+            
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                @Key("displayMode", migratingLegacyKey: "old_display_mode")
+                var mode: ThrowingValue<DisplayMode> { get }
+            }
+            """
+        } expansion: {
+          #"""
+          enum DisplayMode: Int {
+              case compact = 0
+              case expanded = 1
+          }
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var mode: ThrowingValue<DisplayMode> { get }
+          }
+
+          private enum ThrowingSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ThrowingSettings.mode: "displayMode"
+              ]
+          }
+
+          extension ThrowingSettings {
+              var mode: ThrowingValue<DisplayMode> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  if let rawValue = try self.object(forKey: "displayMode"), let value = (DisplayMode)(rawValue: rawValue as! DisplayMode.RawValue) {
+                      return value
+                  }
+                  // Migration
+                  if let legacyRawValue = try self.object(forKey: "old_display_mode"), let legacyValue = (DisplayMode)(rawValue: legacyRawValue as! DisplayMode.RawValue) {
+                      if let rawValue = (legacyValue as? any RawRepresentable)?.rawValue {
+                          try self.set(rawValue, forKey: "displayMode")
+                      }
+                      try self.removeObject(forKey: "old_display_mode")
+                      return legacyValue
+                  }
+                  return nil
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      if let rawValue = (newValue as? any RawRepresentable)?.rawValue {
+                          try self.set(rawValue, forKey: "displayMode")
+                      } else {
+                          try self.set(newValue, forKey: "displayMode")
+                      }
+                  } else {
+                      try self.removeObject(forKey: "displayMode")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("ThrowingValue with multiple properties and mixed keys")
+    func testThrowingValueMixedKeys() {
+        assertMacro {
+            """
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                var defaultValue: ThrowingValue<String> { get }
+                
+                @Key("custom_key")
+                var customValue: ThrowingValue<Int> { get }
+                
+                @Key("migrated", migratingLegacyKey: "old.migrated")
+                var migratedValue: ThrowingValue<Bool> { get }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var defaultValue: ThrowingValue<String> { get }
+              
+              var customValue: ThrowingValue<Int> { get }
+              
+              var migratedValue: ThrowingValue<Bool> { get }
+          }
+
+          private enum ThrowingSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ThrowingSettings.defaultValue: "defaultValue",
+                  \ThrowingSettings.customValue: "custom_key",
+                  \ThrowingSettings.migratedValue: "migrated"
+              ]
+          }
+
+          extension ThrowingSettings {
+              var defaultValue: ThrowingValue<String> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "defaultValue") as? String
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "defaultValue")
+                  } else {
+                      try self.removeObject(forKey: "defaultValue")
+                  }
+                          }
+                      )
+                  }
+              }
+              var customValue: ThrowingValue<Int> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "custom_key") as? Int
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "custom_key")
+                  } else {
+                      try self.removeObject(forKey: "custom_key")
+                  }
+                          }
+                      )
+                  }
+              }
+              var migratedValue: ThrowingValue<Bool> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  if let value = try self.object(forKey: "migrated") as? Bool {
+                      return value
+                  }
+                  // Migration: check legacy key
+                  if let legacyValue = try self.object(forKey: "old.migrated") as? Bool {
+                      try self.set(legacyValue, forKey: "migrated")
+                      try self.removeObject(forKey: "old.migrated")
+                      return legacyValue
+                  }
+                  return nil
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "migrated")
+                  } else {
+                      try self.removeObject(forKey: "migrated")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("ThrowingValue with Data type")
+    func testThrowingValueWithData() {
+        assertMacro {
+            """
+            import Foundation
+            
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                var blob: ThrowingValue<Data> { get }
+            }
+            """
+        } expansion: {
+          #"""
+          import Foundation
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var blob: ThrowingValue<Data> { get }
+          }
+
+          private enum ThrowingSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ThrowingSettings.blob: "blob"
+              ]
+          }
+
+          extension ThrowingSettings {
+              var blob: ThrowingValue<Data> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "blob") as? Data
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "blob")
+                  } else {
+                      try self.removeObject(forKey: "blob")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("ThrowingValue with Array type")
+    func testThrowingValueWithArray() {
+        assertMacro {
+            """
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                var items: ThrowingValue<[String]> { get }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var items: ThrowingValue<[String]> { get }
+          }
+
+          private enum ThrowingSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ThrowingSettings.items: "items"
+              ]
+          }
+
+          extension ThrowingSettings {
+              var items: ThrowingValue<[String]> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "items") as? [String]
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "items")
+                  } else {
+                      try self.removeObject(forKey: "items")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("ThrowingValue with Dictionary type")
+    func testThrowingValueWithDictionary() {
+        assertMacro {
+            """
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                var metadata: ThrowingValue<[String: Int]> { get }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var metadata: ThrowingValue<[String: Int]> { get }
+          }
+
+          private enum ThrowingSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ThrowingSettings.metadata: "metadata"
+              ]
+          }
+
+          extension ThrowingSettings {
+              var metadata: ThrowingValue<[String: Int]> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "metadata") as? [String: Int]
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "metadata")
+                  } else {
+                      try self.removeObject(forKey: "metadata")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Error: ThrowingKeyValueStoring without ThrowingValue wrapper")
+    func testThrowingKeyValueStoringRequiresThrowingValue() {
+        assertMacro {
+            """
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                var username: String? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage with ThrowingKeyValueStoring requires properties to use ThrowingValue<T> or ThrowingGetter<T>. Property 'username' has type 'String?'. Use 'var username: ThrowingValue<String> { get }' for read-write or 'var username: ThrowingGetter<String> { get }' for read-only.
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var username: String? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Error: ThrowingValue with non-optional inner type")
+    func testThrowingValueRequiresOptionalInnerType() {
+        assertMacro {
+            """
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                var username: ThrowingValue<String> { get }
+            }
+            """
+        } diagnostics: {
+          """
+
+          """
+        } expansion: {
+          #"""
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var username: ThrowingValue<String> { get }
+          }
+
+          private enum ThrowingSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ThrowingSettings.username: "username"
+              ]
+          }
+
+          extension ThrowingSettings {
+              var username: ThrowingValue<String> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "username") as? String
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "username")
+                  } else {
+                      try self.removeObject(forKey: "username")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("ThrowingValue no publisher generation")
+    func testThrowingValueNoPublishers() {
+        assertMacro {
+            """
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                var value: ThrowingValue<Int> { get }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var value: ThrowingValue<Int> { get }
+          }
+
+          private enum ThrowingSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ThrowingSettings.value: "value"
+              ]
+          }
+
+          extension ThrowingSettings {
+              var value: ThrowingValue<Int> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "value") as? Int
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "value")
+                  } else {
+                      try self.removeObject(forKey: "value")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Public ThrowingValue properties")
+    func testPublicThrowingValue() {
+        assertMacro {
+            """
+            @Storage
+            public protocol ThrowingSettings: ThrowingKeyValueStoring {
+                var username: ThrowingValue<String> { get }
+            }
+            """
+        } expansion: {
+          #"""
+          public protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var username: ThrowingValue<String> { get }
+          }
+
+          private enum ThrowingSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ThrowingSettings.username: "username"
+              ]
+          }
+
+          extension ThrowingSettings {
+              public var username: ThrowingValue<String> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "username") as? String
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "username")
+                  } else {
+                      try self.removeObject(forKey: "username")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Internal protocol generates internal accessors")
+    func testInternalProtocol() {
+        assertMacro {
+            """
+            @Storage
+            internal protocol Settings: KeyValueStoring {
+                var value: String? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          internal protocol Settings: KeyValueStoring {
+              var value: String? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.value: "value"
+              ]
+          }
+
+          extension Settings {
+              var value: String? {
+                  get {
+                      return self.object(forKey: "value") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "value")
+                              } else {
+                                  self.removeObject(forKey: "value")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Private protocol generates private accessors")
+    func testPrivateProtocol() {
+        assertMacro {
+            """
+            @Storage
+            private protocol Settings: KeyValueStoring {
+                var value: String? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          private protocol Settings: KeyValueStoring {
+              var value: String? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.value: "value"
+              ]
+          }
+
+          extension Settings {
+              private var value: String? {
+                  get {
+                      return self.object(forKey: "value") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "value")
+                              } else {
+                                  self.removeObject(forKey: "value")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Fileprivate protocol generates fileprivate accessors")
+    func testFileprivateProtocol() {
+        assertMacro {
+            """
+            @Storage
+            fileprivate protocol Settings: KeyValueStoring {
+                var value: String? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          fileprivate protocol Settings: KeyValueStoring {
+              var value: String? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.value: "value"
+              ]
+          }
+
+          extension Settings {
+              fileprivate var value: String? {
+                  get {
+                      return self.object(forKey: "value") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "value")
+                              } else {
+                                  self.removeObject(forKey: "value")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Public ObservableKeyValueStoring generates public accessors")
+    func testPublicObservableProtocol() {
+        assertMacro {
+            """
+            @Storage
+            public protocol Settings: ObservableKeyValueStoring {
+                var value: String? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          public protocol Settings: ObservableKeyValueStoring {
+              var value: String? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.value: "value"
+              ]
+          }
+
+          extension Settings {
+              public var value: String? {
+                  get {
+                      _setupAutoObservationIfNeeded()
+                              return self.object(forKey: "value") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "value")
+                              } else {
+                                  self.removeObject(forKey: "value")
+                              }
+                  }
+              }
+          }
+
+          extension Settings where Self: ObservableKeyValueStoring {
+              public var $value: AnyPublisher<String?, Never> {
+                  publisher(for: \Settings.value, key: "value")
+              }
+              public func publisher<Value>(for keyPath: KeyPath<Settings, Value?>) -> AnyPublisher<Value?, Never> {
+                  guard let key = SettingsKeyPathMapping.keyPathToStorageKey[keyPath] else {
+                      fatalError("Unknown keyPath: \(keyPath)")
+                  }
+                  return publisher(for: keyPath, key: key)
+              }
+              private func publisher<Value>(for keyPath: KeyPath<Settings, Value?>, key: String) -> AnyPublisher<Value?, Never> {
+                  self.updatesPublisher(forKey: key)
+                      .prepend( () )
+                      .map {
+                          self [keyPath: keyPath]
+                      }
+                      .eraseToAnyPublisher()
+              }
+              private var _Settings_observationCancellable: AnyCancellable? {
+                  get {
+                      guard let userDefaults = self as? UserDefaults else {
+                          return nil
+                      }
+                      let key = unsafeBitCast(Selector(("_Settings_observationCancellable")), to: UnsafeRawPointer.self)
+                      return objc_getAssociatedObject(userDefaults, key) as? AnyCancellable
+                  }
+                  set {
+                      guard let userDefaults = self as? UserDefaults else {
+                          return
+                      }
+                      let key = unsafeBitCast(Selector(("_Settings_observationCancellable")), to: UnsafeRawPointer.self)
+                      objc_setAssociatedObject(userDefaults, key, newValue, .OBJC_ASSOCIATION_RETAIN)
+                  }
+              }
+
+          private func _setupAutoObservationIfNeeded() {
+              guard let userDefaults = self as? UserDefaults else { return }
+              
+              if _Settings_observationCancellable != nil {
+                  return
+              }
+              
+              // Subscribe to all publishers for keys in this protocol
+              let keys = ["value"]
+              let publishers = keys.map { userDefaults.updatesPublisher(forKey: $0) }
+              
+              let cancellable = Publishers.MergeMany(publishers)
+                  .sink { [weak userDefaults] _ in
+                      userDefaults?.objectWillChange.send()
+                  }
+              
+              _Settings_observationCancellable = cancellable
+          }
+          }
+          """#
+        }
+    }
+    
+    @Test("ThrowingValue with @StorageIgnored")
+    func testThrowingValueWithIgnored() {
+        assertMacro {
+            """
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                var stored: ThrowingValue<String> { get }
+                
+                @StorageIgnored
+                func customMethod()
+            }
+            """
+        } expansion: {
+          #"""
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var stored: ThrowingValue<String> { get }
+              
+              func customMethod()
+          }
+
+          private enum ThrowingSettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \ThrowingSettings.stored: "stored"
+              ]
+          }
+
+          extension ThrowingSettings {
+              var stored: ThrowingValue<String> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "stored") as? String
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "stored")
+                  } else {
+                      try self.removeObject(forKey: "stored")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    // MARK: - Protocol Conformance Validation Tests
+    
+    @Test("Protocol with AnyObject conformance")
+    func testProtocolWithAnyObject() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: AnyObject, KeyValueStoring {
+                var value: String? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol Settings: AnyObject, KeyValueStoring {
+              var value: String? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.value: "value"
+              ]
+          }
+
+          extension Settings {
+              var value: String? {
+                  get {
+                      return self.object(forKey: "value") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "value")
+                              } else {
+                                  self.removeObject(forKey: "value")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Protocol with multiple non-storage conformances")
+    func testProtocolWithMultipleConformances() {
+        assertMacro {
+            """
+            protocol CustomProtocol {}
+            
+            @Storage
+            protocol Settings: AnyObject, CustomProtocol, ObservableKeyValueStoring {
+                var value: Int? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol CustomProtocol {}
+          protocol Settings: AnyObject, CustomProtocol, ObservableKeyValueStoring {
+              var value: Int? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.value: "value"
+              ]
+          }
+
+          extension Settings {
+              var value: Int? {
+                  get {
+                      _setupAutoObservationIfNeeded()
+                              return self.object(forKey: "value") as? Int
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "value")
+                              } else {
+                                  self.removeObject(forKey: "value")
+                              }
+                  }
+              }
+          }
+
+          extension Settings where Self: ObservableKeyValueStoring {
+              var $value: AnyPublisher<Int?, Never> {
+                  publisher(for: \Settings.value, key: "value")
+              }
+              func publisher<Value>(for keyPath: KeyPath<Settings, Value?>) -> AnyPublisher<Value?, Never> {
+                  guard let key = SettingsKeyPathMapping.keyPathToStorageKey[keyPath] else {
+                      fatalError("Unknown keyPath: \(keyPath)")
+                  }
+                  return publisher(for: keyPath, key: key)
+              }
+              private func publisher<Value>(for keyPath: KeyPath<Settings, Value?>, key: String) -> AnyPublisher<Value?, Never> {
+                  self.updatesPublisher(forKey: key)
+                      .prepend( () )
+                      .map {
+                          self [keyPath: keyPath]
+                      }
+                      .eraseToAnyPublisher()
+              }
+              private var _Settings_observationCancellable: AnyCancellable? {
+                  get {
+                      guard let userDefaults = self as? UserDefaults else {
+                          return nil
+                      }
+                      let key = unsafeBitCast(Selector(("_Settings_observationCancellable")), to: UnsafeRawPointer.self)
+                      return objc_getAssociatedObject(userDefaults, key) as? AnyCancellable
+                  }
+                  set {
+                      guard let userDefaults = self as? UserDefaults else {
+                          return
+                      }
+                      let key = unsafeBitCast(Selector(("_Settings_observationCancellable")), to: UnsafeRawPointer.self)
+                      objc_setAssociatedObject(userDefaults, key, newValue, .OBJC_ASSOCIATION_RETAIN)
+                  }
+              }
+
+          private func _setupAutoObservationIfNeeded() {
+              guard let userDefaults = self as? UserDefaults else { return }
+              
+              if _Settings_observationCancellable != nil {
+                  return
+              }
+              
+              // Subscribe to all publishers for keys in this protocol
+              let keys = ["value"]
+              let publishers = keys.map { userDefaults.updatesPublisher(forKey: $0) }
+              
+              let cancellable = Publishers.MergeMany(publishers)
+                  .sink { [weak userDefaults] _ in
+                      userDefaults?.objectWillChange.send()
+                  }
+              
+              _Settings_observationCancellable = cancellable
+          }
+          }
+          """#
+        }
+    }
+    
+    @Test("Error: Protocol without any storage conformance")
+    func testProtocolWithoutStorageConformance() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: AnyObject {
+                var value: String? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage requires the protocol to inherit from exactly one of: KeyValueStoring, ThrowingKeyValueStoring, ObservableKeyValueStoring, or ObservableThrowingKeyValueStoring
+          protocol Settings: AnyObject {
+              var value: String? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Error: Protocol with multiple storage conformances - KeyValueStoring + ObservableKeyValueStoring")
+    func testProtocolWithMultipleStorageConformances1() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring, ObservableKeyValueStoring {
+                var value: String? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage protocol cannot inherit from multiple storage protocols. Found: KeyValueStoring, ObservableKeyValueStoring. Choose exactly one.
+          protocol Settings: KeyValueStoring, ObservableKeyValueStoring {
+              var value: String? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Error: Protocol with multiple storage conformances - ThrowingKeyValueStoring + ObservableKeyValueStoring")
+    func testProtocolWithMultipleStorageConformances2() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: ThrowingKeyValueStoring, ObservableKeyValueStoring {
+                var value: ThrowingValue<String> { get }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage protocol cannot inherit from multiple storage protocols. Found: ThrowingKeyValueStoring, ObservableKeyValueStoring. Choose exactly one.
+          protocol Settings: ThrowingKeyValueStoring, ObservableKeyValueStoring {
+              var value: ThrowingValue<String> { get }
+          }
+          """
+        }
+    }
+    
+    @Test("Error: Protocol with multiple storage conformances - KeyValueStoring + ThrowingKeyValueStoring")
+    func testProtocolWithMultipleStorageConformances3() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring, ThrowingKeyValueStoring {
+                var value: String? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage protocol cannot inherit from multiple storage protocols. Found: KeyValueStoring, ThrowingKeyValueStoring. Choose exactly one.
+          protocol Settings: KeyValueStoring, ThrowingKeyValueStoring {
+              var value: String? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Protocol with Sendable conformance")
+    func testProtocolWithSendable() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring, Sendable {
+                var value: String? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol Settings: KeyValueStoring, Sendable {
+              var value: String? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.value: "value"
+              ]
+          }
+
+          extension Settings {
+              var value: String? {
+                  get {
+                      return self.object(forKey: "value") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "value")
+                              } else {
+                                  self.removeObject(forKey: "value")
+                              }
+                  }
+              }
+          }
+          """#
+        }
+    }
+    
+    @Test("Protocol with custom protocol before storage protocol")
+    func testProtocolWithCustomProtocolFirst() {
+        assertMacro {
+            """
+            protocol Identifiable {
+                var id: String { get }
+            }
+            
+            @Storage
+            protocol Settings: Identifiable, ObservableKeyValueStoring {
+                var username: String? { get set }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol Identifiable {
+              var id: String { get }
+          }
+          protocol Settings: Identifiable, ObservableKeyValueStoring {
+              var username: String? { get set }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.username: "username"
+              ]
+          }
+
+          extension Settings {
+              var username: String? {
+                  get {
+                      _setupAutoObservationIfNeeded()
+                              return self.object(forKey: "username") as? String
+                  }
+                  set {
+                      if let newValue = newValue {
+                                  self.set(newValue, forKey: "username")
+                              } else {
+                                  self.removeObject(forKey: "username")
+                              }
+                  }
+              }
+          }
+
+          extension Settings where Self: ObservableKeyValueStoring {
+              var $username: AnyPublisher<String?, Never> {
+                  publisher(for: \Settings.username, key: "username")
+              }
+              func publisher<Value>(for keyPath: KeyPath<Settings, Value?>) -> AnyPublisher<Value?, Never> {
+                  guard let key = SettingsKeyPathMapping.keyPathToStorageKey[keyPath] else {
+                      fatalError("Unknown keyPath: \(keyPath)")
+                  }
+                  return publisher(for: keyPath, key: key)
+              }
+              private func publisher<Value>(for keyPath: KeyPath<Settings, Value?>, key: String) -> AnyPublisher<Value?, Never> {
+                  self.updatesPublisher(forKey: key)
+                      .prepend( () )
+                      .map {
+                          self [keyPath: keyPath]
+                      }
+                      .eraseToAnyPublisher()
+              }
+              private var _Settings_observationCancellable: AnyCancellable? {
+                  get {
+                      guard let userDefaults = self as? UserDefaults else {
+                          return nil
+                      }
+                      let key = unsafeBitCast(Selector(("_Settings_observationCancellable")), to: UnsafeRawPointer.self)
+                      return objc_getAssociatedObject(userDefaults, key) as? AnyCancellable
+                  }
+                  set {
+                      guard let userDefaults = self as? UserDefaults else {
+                          return
+                      }
+                      let key = unsafeBitCast(Selector(("_Settings_observationCancellable")), to: UnsafeRawPointer.self)
+                      objc_setAssociatedObject(userDefaults, key, newValue, .OBJC_ASSOCIATION_RETAIN)
+                  }
+              }
+
+          private func _setupAutoObservationIfNeeded() {
+              guard let userDefaults = self as? UserDefaults else { return }
+              
+              if _Settings_observationCancellable != nil {
+                  return
+              }
+              
+              // Subscribe to all publishers for keys in this protocol
+              let keys = ["username"]
+              let publishers = keys.map { userDefaults.updatesPublisher(forKey: $0) }
+              
+              let cancellable = Publishers.MergeMany(publishers)
+                  .sink { [weak userDefaults] _ in
+                      userDefaults?.objectWillChange.send()
+                  }
+              
+              _Settings_observationCancellable = cancellable
+          }
+          }
+          """#
+        }
+    }
+    
+    @Test("Error: Protocol without storage protocol conformance")
+    func testProtocolNoStorageInheritance() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings {
+                var value: String? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage requires the protocol to inherit from exactly one of: KeyValueStoring, ThrowingKeyValueStoring, ObservableKeyValueStoring, or ObservableThrowingKeyValueStoring
+          protocol Settings {
+              var value: String? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Error: ThrowingValue with get set accessor")
+    func testThrowingValueWithGetSet() {
+        assertMacro {
+            """
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                var username: ThrowingValue<String> { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage with ThrowingValue requires read-only properties. Property 'username' must be declared as '{ get }', not '{ get set }'.
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var username: ThrowingValue<String> { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Error: ThrowingValue with optional inner type")
+    func testThrowingValueOptionalInnerType() {
+        assertMacro {
+            """
+            @Storage
+            protocol ThrowingSettings: ThrowingKeyValueStoring {
+                var username: ThrowingValue<String?> { get }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage with ThrowingValue requires the inner type to be non-optional. Property 'username' has type 'ThrowingValue<String?>' but should be 'ThrowingValue<String>'.
+          protocol ThrowingSettings: ThrowingKeyValueStoring {
+              var username: ThrowingValue<String?> { get }
+          }
+          """
+        }
+    }
+    
+    // MARK: - ObservableThrowingKeyValueStoring Tests
+    
+    @Test("ObservableThrowingKeyValueStoring with ThrowingValue properties")
+    func testObservableThrowingKeyValueStoring() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: ObservableThrowingKeyValueStoring {
+                var username: ThrowingValue<String> { get }
+                var count: ThrowingValue<Int> { get }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol Settings: ObservableThrowingKeyValueStoring {
+              var username: ThrowingValue<String> { get }
+              var count: ThrowingValue<Int> { get }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.username: "username",
+                  \Settings.count: "count"
+              ]
+          }
+
+          extension Settings {
+              var username: ThrowingValue<String> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "username") as? String
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "username")
+                  } else {
+                      try self.removeObject(forKey: "username")
+                  }
+                          }
+                      )
+                  }
+              }
+              var count: ThrowingValue<Int> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "count") as? Int
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "count")
+                  } else {
+                      try self.removeObject(forKey: "count")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+
+          extension Settings where Self: ObservableThrowingKeyValueStoring {
+              func publisher<Value>(for keyPath: KeyPath<Settings, ThrowingValue<Value>>) -> AnyPublisher<Value?, Never> {
+                  guard let key = SettingsKeyPathMapping.keyPathToStorageKey[keyPath] else {
+                      fatalError("Unknown keyPath: \(keyPath)")
+                  }
+                  return publisher(for: keyPath, key: key)
+              }
+              private func publisher<Value>(for keyPath: KeyPath<Settings, ThrowingValue<Value>>, key: String) -> AnyPublisher<Value?, Never> {
+                  self.updatesPublisher(forKey: key)
+                      .prepend( () )
+                      .map { [weak self] in
+                          try? self? [keyPath: keyPath].get()
+                      }
+                      .eraseToAnyPublisher()
+              }
+              private var _Settings_observationCancellable: AnyCancellable? {
+                  get {
+                      guard let userDefaults = self as? UserDefaults else {
+                          return nil
+                      }
+                      let key = unsafeBitCast(Selector(("_Settings_observationCancellable")), to: UnsafeRawPointer.self)
+                      return objc_getAssociatedObject(userDefaults, key) as? AnyCancellable
+                  }
+                  set {
+                      guard let userDefaults = self as? UserDefaults else {
+                          return
+                      }
+                      let key = unsafeBitCast(Selector(("_Settings_observationCancellable")), to: UnsafeRawPointer.self)
+                      objc_setAssociatedObject(userDefaults, key, newValue, .OBJC_ASSOCIATION_RETAIN)
+                  }
+              }
+
+          private func _setupAutoObservationIfNeeded() {
+              guard let userDefaults = self as? UserDefaults else { return }
+              
+              if _Settings_observationCancellable != nil {
+                  return
+              }
+              
+              // Subscribe to all publishers for keys in this protocol
+              let keys = ["username", "count"]
+              let publishers = keys.map { userDefaults.updatesPublisher(forKey: $0) }
+              
+              let cancellable = Publishers.MergeMany(publishers)
+                  .sink { [weak userDefaults] _ in
+                      userDefaults?.objectWillChange.send()
+                  }
+              
+              _Settings_observationCancellable = cancellable
+          }
+          }
+          """#
+        }
+    }
+    
+    @Test("ObservableThrowingKeyValueStoring with custom keys")
+    func testObservableThrowingKeyValueStoringWithCustomKeys() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: ObservableThrowingKeyValueStoring {
+                @Key("user_name")
+                var username: ThrowingValue<String> { get }
+            }
+            """
+        } expansion: {
+          #"""
+          protocol Settings: ObservableThrowingKeyValueStoring {
+              var username: ThrowingValue<String> { get }
+          }
+
+          private enum SettingsKeyPathMapping {
+              static let keyPathToStorageKey: [AnyKeyPath: String] = [
+                  \Settings.username: "user_name"
+              ]
+          }
+
+          extension Settings {
+              var username: ThrowingValue<String> {
+                  get {
+                      ThrowingValue(
+                          getter: {
+                  return try self.object(forKey: "user_name") as? String
+                          },
+                          setter: { newValue in
+                  if let newValue = newValue {
+                      try self.set(newValue, forKey: "user_name")
+                  } else {
+                      try self.removeObject(forKey: "user_name")
+                  }
+                          }
+                      )
+                  }
+              }
+          }
+
+          extension Settings where Self: ObservableThrowingKeyValueStoring {
+              func publisher<Value>(for keyPath: KeyPath<Settings, ThrowingValue<Value>>) -> AnyPublisher<Value?, Never> {
+                  guard let key = SettingsKeyPathMapping.keyPathToStorageKey[keyPath] else {
+                      fatalError("Unknown keyPath: \(keyPath)")
+                  }
+                  return publisher(for: keyPath, key: key)
+              }
+              private func publisher<Value>(for keyPath: KeyPath<Settings, ThrowingValue<Value>>, key: String) -> AnyPublisher<Value?, Never> {
+                  self.updatesPublisher(forKey: key)
+                      .prepend( () )
+                      .map { [weak self] in
+                          try? self? [keyPath: keyPath].get()
+                      }
+                      .eraseToAnyPublisher()
+              }
+              private var _Settings_observationCancellable: AnyCancellable? {
+                  get {
+                      guard let userDefaults = self as? UserDefaults else {
+                          return nil
+                      }
+                      let key = unsafeBitCast(Selector(("_Settings_observationCancellable")), to: UnsafeRawPointer.self)
+                      return objc_getAssociatedObject(userDefaults, key) as? AnyCancellable
+                  }
+                  set {
+                      guard let userDefaults = self as? UserDefaults else {
+                          return
+                      }
+                      let key = unsafeBitCast(Selector(("_Settings_observationCancellable")), to: UnsafeRawPointer.self)
+                      objc_setAssociatedObject(userDefaults, key, newValue, .OBJC_ASSOCIATION_RETAIN)
+                  }
+              }
+
+          private func _setupAutoObservationIfNeeded() {
+              guard let userDefaults = self as? UserDefaults else { return }
+              
+              if _Settings_observationCancellable != nil {
+                  return
+              }
+              
+              // Subscribe to all publishers for keys in this protocol
+              let keys = ["user_name"]
+              let publishers = keys.map { userDefaults.updatesPublisher(forKey: $0) }
+              
+              let cancellable = Publishers.MergeMany(publishers)
+                  .sink { [weak userDefaults] _ in
+                      userDefaults?.objectWillChange.send()
+                  }
+              
+              _Settings_observationCancellable = cancellable
+          }
+          }
+          """#
+        }
+    }
+    
+    @Test("Error: ObservableThrowingKeyValueStoring requires ThrowingValue")
+    func testObservableThrowingKeyValueStoringRequiresThrowingValue() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: ObservableThrowingKeyValueStoring {
+                var value: String? { get set }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage with ThrowingKeyValueStoring requires properties to use ThrowingValue<T> or ThrowingGetter<T>. Property 'value' has type 'String?'. Use 'var value: ThrowingValue<String> { get }' for read-write or 'var value: ThrowingGetter<String> { get }' for read-only.
+          protocol Settings: ObservableThrowingKeyValueStoring {
+              var value: String? { get set }
+          }
+          """
+        }
+    }
+    
+    @Test("Error: ThrowingValue used with non-throwing protocol")
+    func testThrowingValueWithNonThrowingProtocol() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: KeyValueStoring {
+                var value: ThrowingValue<String> { get }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage property 'value' uses ThrowingValue<T> but the protocol 'Settings' does not conform to ThrowingKeyValueStoring or ObservableThrowingKeyValueStoring. Either change the property to a regular optional type or make the protocol conform to a throwing protocol.
+          protocol Settings: KeyValueStoring {
+              var value: ThrowingValue<String> { get }
+          }
+          """
+        }
+    }
+    
+    @Test("Error: ThrowingValue used with ObservableKeyValueStoring")
+    func testThrowingValueWithObservableKeyValueStoring() {
+        assertMacro {
+            """
+            @Storage
+            protocol Settings: ObservableKeyValueStoring {
+                var value: ThrowingValue<Int> { get }
+            }
+            """
+        } diagnostics: {
+          """
+          @Storage
+          ┬───────
+          ╰─ 🛑 @Storage property 'value' uses ThrowingValue<T> but the protocol 'Settings' does not conform to ThrowingKeyValueStoring or ObservableThrowingKeyValueStoring. Either change the property to a regular optional type or make the protocol conform to a throwing protocol.
+          protocol Settings: ObservableKeyValueStoring {
+              var value: ThrowingValue<Int> { get }
+          }
+          """
+        }
+    }
+}
+

--- a/Tests/MacrosTests/URLMacroTests.swift
+++ b/Tests/MacrosTests/URLMacroTests.swift
@@ -20,13 +20,15 @@ import MacrosImplementation
 import MacroTesting
 import SwiftSyntaxMacros
 import SwiftSyntaxMacrosTestSupport
-import XCTest
+import Testing
 
-final class URLMacroTests: XCTestCase {
+@Suite("URL Macro Tests")
+struct URLMacroTests {
 
     private let macros: [String: Macro.Type] = ["URL": URLMacro.self]
 
-    func testWhenURLMacroAppliedToValidURLs_UrlIniIsGenerated() {
+    @Test("URL macro applied to valid URLs generates URL init")
+    func urlMacroAppliedToValidURLsGeneratesUrlInit() {
         let startLine = #line + 2
         let urls = [
             "http://example.com",
@@ -85,7 +87,8 @@ final class URLMacroTests: XCTestCase {
         }
     }
 
-    func testWhenURLMacroAppliedToURLWithoutScheme_diagnosticsErrorIsReturned() {
+    @Test("URL macro applied to URL without scheme returns diagnostics error")
+    func urlMacroAppliedToURLWithoutSchemeReturnsDiagnosticsError() {
         let startLine = #line + 2
         let urls = [
             "user@somehost.local:9091/index.html",
@@ -120,7 +123,8 @@ final class URLMacroTests: XCTestCase {
         }
     }
 
-    func testWhenURLMacroAppliedToURLsWithInvalidCharacter_diagnosticsErrorIsReturned() {
+    @Test("URL macro applied to URLs with invalid character returns diagnostics error")
+    func urlMacroAppliedToURLsWithInvalidCharacterReturnsDiagnosticsError() {
         let startLine = #line + 2
         let urls: [(String, invalidCharacter: Character)] = [
             ("sheep%2B:P%40%24swrd@💩.la?arg=b#1", "💩"),
@@ -151,8 +155,9 @@ final class URLMacroTests: XCTestCase {
         }
     }
 
-    func testWhenInvalidArgumentProvided_URLMacroFails() {
-        assertMacro(macros, record: false) {
+    @Test("URL macro fails when invalid argument provided")
+    func urlMacroFailsWhenInvalidArgumentProvided() {
+        assertMacro(macros) {
             """
             let s = "duckduckgo.com/"
             let _=#URL(s)
@@ -166,7 +171,7 @@ final class URLMacroTests: XCTestCase {
             """
         }
 
-        assertMacro(macros, record: false) {
+        assertMacro(macros) {
             """
             #URL(duckduckgo)
             """
@@ -178,7 +183,7 @@ final class URLMacroTests: XCTestCase {
             """
         }
 
-        assertMacro(macros, record: false) {
+        assertMacro(macros) {
             """
             #URL(1)
             """
@@ -191,8 +196,9 @@ final class URLMacroTests: XCTestCase {
         }
     }
 
-    func testWhenTooManyArgsProvided_URLMacroFails() {
-        assertMacro(macros, record: false) {
+    @Test("URL macro fails when too many args provided")
+    func urlMacroFailsWhenTooManyArgsProvided() {
+        assertMacro(macros) {
             """
             #URL("duckduckgo.com", "duckduckgo.com")
             """


### PR DESCRIPTION
Task URL: https://app.asana.com/1/137249556945/inbox/1202406491309505/item/1209396651641128/story/1211770901627242
Tech Design: https://app.asana.com/1/137249556945/project/481882893211075/task/1211766119261704?focus=true
CC: @brindy @ayoy 

Description:
- Add `@Storage` macro for protocoled, compile-time checked `KeyValueStoring`/`ThrowingKeyValueStoring` access
- Add `@NestedObservableObject` macro for nesting `ObservableObject`s in SwiftUI