### PR TITLE
Fix JSON escaping in asana-create-pr-subtask

### DIFF
--- a/actions/asana-create-pr-subtask/asana-create-pr-subtask.sh
+++ b/actions/asana-create-pr-subtask/asana-create-pr-subtask.sh
@@ -94,16 +94,12 @@ _create_pr_subtask() {
 	local due_date=$(_get_next_business_day)
 
 	local payload
-	payload=$(cat <<-EOF
-		{
-			"data": {
-				"assignee": "${asana_assignee_id}",
-				"notes": "${pr_prefix} ${github_pr_url}",
-				"name": "${task_name}",
-				"due_on": "${due_date}"
-			}
-		}
-		EOF
+	payload=$(jq -n \
+		--arg assignee "$asana_assignee_id" \
+		--arg notes "${pr_prefix} ${github_pr_url}" \
+		--arg name "$task_name" \
+		--arg due_on "$due_date" \
+		'{ data: { assignee: $assignee, notes: $notes, name: $name, due_on: $due_on } }'
 	)
 
 	_execute_create_or_update_asana_task_request POST "$url" "$payload"


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1213613886098883?focus=true

## Description
- Fix `asana-create-pr-subtask.sh` failing when the Asana task name contains quotes or other JSON-special characters
- Replace heredoc-based JSON construction with `jq -n --arg`, which properly escapes all special characters

## Test plan
- [ ] Verify the workflow runs successfully on a PR linked to an Asana task with quotes in the name


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 7e9de2f36a89df0a691ddbdb9efe67b3ab102549. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->