### PR TITLE
Add PR author to the PR subtask

### DIFF
--- a/actions/asana-create-pr-subtask/action.yml
+++ b/actions/asana-create-pr-subtask/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: "GitHub username for the PR author"
     required: true
     type: string
+  github-pr-author-type:
+    description: "GitHub user type of the PR author ('User' or 'Bot'). Pass github.event.pull_request.user.type."
+    required: true
+    type: string
   github-token:
     description: "GitHub token"
     required: false
@@ -36,6 +40,11 @@ runs:
 
       - name: Get PR author Asana user ID
         id: get-asana-author-id
+        # Skip the lookup for bot authors (Dependabot, renovate, github-actions, etc.).
+        # Still best-effort for humans — the downstream script handles an empty
+        # author gid gracefully (followers defaults to []).
+        if: ${{ inputs.github-pr-author-type != 'Bot' }}
+        continue-on-error: true
         uses: duckduckgo/native-github-asana-sync@v1.9
         with:
           action: 'get-asana-user-id'

--- a/actions/asana-create-pr-subtask/action.yml
+++ b/actions/asana-create-pr-subtask/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: "GitHub username for the requested reviewer"
     required: true
     type: string
+  github-pr-author-user:
+    description: "GitHub username for the PR author"
+    required: true
+    type: string
   github-token:
     description: "GitHub token"
     required: false
@@ -28,6 +32,14 @@ runs:
         with:
           action: 'get-asana-user-id'
           github-username: ${{ inputs.github-reviewer-user }}
+          github-pat: ${{ inputs.github-token }}
+
+      - name: Get PR author Asana user ID
+        id: get-asana-author-id
+        uses: duckduckgo/native-github-asana-sync@v1.9
+        with:
+          action: 'get-asana-user-id'
+          github-username: ${{ inputs.github-pr-author-user }}
           github-pat: ${{ inputs.github-token }}
 
       - name: Get PR URL
@@ -46,5 +58,5 @@ runs:
             echo "Error: Failed to get Asana user ID for GitHub user ${{ inputs.github-reviewer-user }}"
             exit 1
           else
-            ${{ github.action_path }}/asana-create-pr-subtask.sh ${{ inputs.asana-task-id }} ${{ steps.get-asana-user-id.outputs.asanaUserId }} ${{ steps.get-pr-url.outputs.url }} ${{ github.event.repository.name }}
+            ${{ github.action_path }}/asana-create-pr-subtask.sh ${{ inputs.asana-task-id }} ${{ steps.get-asana-user-id.outputs.asanaUserId }} ${{ steps.get-pr-url.outputs.url }} ${{ github.event.repository.name }} "${{ steps.get-asana-author-id.outputs.asanaUserId }}"
           fi

--- a/actions/asana-create-pr-subtask/asana-create-pr-subtask.sh
+++ b/actions/asana-create-pr-subtask/asana-create-pr-subtask.sh
@@ -88,10 +88,16 @@ _create_pr_subtask() {
 	local asana_assignee_id="$2"
 	local github_pr_url="$3"
 	local github_repo_name="$4"
+	local asana_author_id="$5"
 
 	local url="${asana_api_url}/tasks/${asana_task_id}/subtasks?opt_fields=gid"
 	local task_name="${pr_prefix} ${parent_task_name} (${github_repo_name})"
 	local due_date=$(_get_next_business_day)
+
+	local followers_json='[]'
+	if [[ -n "$asana_author_id" && "$asana_author_id" != "$asana_assignee_id" ]]; then
+		followers_json=$(jq -nc --arg author "$asana_author_id" '[$author]')
+	fi
 
 	local payload
 	payload=$(jq -n \
@@ -99,7 +105,8 @@ _create_pr_subtask() {
 		--arg notes "${pr_prefix} ${github_pr_url}" \
 		--arg name "$task_name" \
 		--arg due_on "$due_date" \
-		'{ data: { assignee: $assignee, notes: $notes, name: $name, due_on: $due_on } }'
+		--argjson followers "$followers_json" \
+		'{ data: { assignee: $assignee, notes: $notes, name: $name, due_on: $due_on, followers: $followers } }'
 	)
 
 	_execute_create_or_update_asana_task_request POST "$url" "$payload"
@@ -144,6 +151,7 @@ main() {
 	local asana_assignee_id="$2"
 	local github_pr_url="$3"
 	local github_repo_name="$4"
+	local asana_author_id="$5"
 
 	# fetch the task subtasks
 	local subtasks
@@ -161,7 +169,7 @@ main() {
 	if [[ -n "$pr_subtask" ]]; then
 		_mark_task_uncompleted_if_needed "$pr_subtask"
 	else
-		_create_pr_subtask "$asana_task_id" "$asana_assignee_id" "$github_pr_url" "$github_repo_name"
+		_create_pr_subtask "$asana_task_id" "$asana_assignee_id" "$github_pr_url" "$github_repo_name" "$asana_author_id"
 	fi
 }
 


### PR DESCRIPTION
This PR adds the PR author to the PR subtasks as follower

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small workflow/script change with graceful fallbacks; breaking only in that consumers must pass two new required inputs.
> 
> **Overview**
> When a new Asana PR subtask is created, the **GitHub PR author** can be added as an Asana **follower** (still assigned to the reviewer). The composite action gains required inputs `github-pr-author-user` and `github-pr-author-type`, a best-effort `get-asana-user-id` step for human authors (skipped for `Bot`, `continue-on-error`), and passes the resolved author gid into `asana-create-pr-subtask.sh`. The script builds a `followers` array (empty if missing, same as assignee, or bot) and includes it in the create-subtask API payload; **existing** PR subtasks are unchanged (no follower backfill on reopen).
> 
> **Callers must wire the new inputs** (e.g. `github.event.pull_request.user.login` and `.type`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57b59e8dbcf7fa98e1a8f7a6d11f0af39127f7d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->