### PR TITLE
[CI] Extend Asana actions to support PR review subtask cleanup

### DIFF
--- a/actions/asana-extract-task-id/action.yml
+++ b/actions/asana-extract-task-id/action.yml
@@ -1,0 +1,30 @@
+name: Extract Asana task ID from PR body
+description: |
+  Extracts an Asana task gid from text that contains a "Task/Issue URL:"
+  line pointing at app.asana.com. Supports both legacy (/0/) and current
+  (/1/) Asana URL shapes. Outputs an empty string when no task URL is
+  found.
+inputs:
+  text:
+    description: "Text to scan (typically github.event.pull_request.body)"
+    required: true
+    type: string
+outputs:
+  task-id:
+    description: "Extracted Asana task gid, or empty string if not found"
+    value: ${{ steps.extract.outputs.task-id }}
+runs:
+  using: "composite"
+  steps:
+      - name: "Extract task ID"
+        id: extract
+        shell: bash
+        env:
+          BODY: ${{ inputs.text }}
+        run: |
+          task_id=$(grep -i "task/issue url.*https://app.asana.com/" <<< "$BODY" \
+            | perl -pe 's|.*https://app.asana.com/0/[0-9]+/([0-9]+)(?:/f)?|\1|; \
+              s|.*https://app.asana.com/1/[0-9]+(?:/[0-9a-z/]*)?/task/([0-9]+)(:?/[0-9a-z/]*)?(?:\?focus=true)?|\1|; \
+              s|.*https://app.asana.com/1/[0-9]+/inbox/[0-9]+/item/([0-9]+)/story/([0-9]+)(?:\?focus=true)?|\1|'
+          )
+          echo "task-id=${task_id//[^0-9]/}" >> "$GITHUB_OUTPUT"

--- a/actions/asana-fetch-pr-subtasks/action.yml
+++ b/actions/asana-fetch-pr-subtasks/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     type: string
   complete:
-    description: "Filter PR subtasks by completion state. 'false' (default) returns only incomplete subtasks; 'true' returns only completed subtasks."
+    description: "Filter PR subtasks by completion state. 'false' (default) returns only incomplete subtasks; 'true' returns only completed subtasks; '' (empty string) disables the filter and returns subtasks in any state."
     required: false
     type: string
     default: 'false'

--- a/actions/asana-fetch-pr-subtasks/action.yml
+++ b/actions/asana-fetch-pr-subtasks/action.yml
@@ -1,8 +1,8 @@
 name: Fetch Asana PR review subtasks
 description: |
-  Fetches PR review subtasks of an Asana parent task. If a GitHub reviewer
-  username is provided, results are filtered to subtasks assigned to that
-  reviewer. If omitted, all PR review subtasks are returned.
+  Fetches PR review subtasks of an Asana parent task. Results are filtered
+  by completion state (incomplete by default) and, optionally, by the
+  GitHub reviewer they're assigned to.
 inputs:
   access-token:
     description: "Asana access token"
@@ -21,6 +21,11 @@ inputs:
     description: "GitHub token. Required only when github-reviewer-user is set (used to resolve the user's Asana gid)."
     required: false
     type: string
+  complete:
+    description: "Filter PR subtasks by completion state. 'false' (default) returns only incomplete subtasks; 'true' returns only completed subtasks."
+    required: false
+    type: string
+    default: 'false'
 outputs:
   subtask-ids:
     description: "JSON array of matching subtask gids. Empty array if none found."
@@ -46,5 +51,6 @@ runs:
           REVIEWER_USER: ${{ inputs.github-reviewer-user }}
           ASSIGNEE_FILTER: ${{ steps.get-asana-user-id.outputs.asanaUserId }}
           REPO_NAME: ${{ github.event.repository.name }}
+          COMPLETE: ${{ inputs.complete }}
         run: |
           ${{ github.action_path }}/asana-fetch-pr-subtasks.sh

--- a/actions/asana-fetch-pr-subtasks/action.yml
+++ b/actions/asana-fetch-pr-subtasks/action.yml
@@ -1,8 +1,8 @@
 name: Fetch Asana PR review subtasks
 description: |
-  Fetches PR review subtasks of an Asana parent task. Results are filtered
-  by completion state (incomplete by default) and, optionally, by the
-  GitHub reviewer they're assigned to.
+  Fetches PR review subtasks of an Asana parent task. Results can be
+  filtered by completion state and, optionally, by the GitHub reviewer
+  they're assigned to. By default no filtering is applied.
 inputs:
   access-token:
     description: "Asana access token"
@@ -22,10 +22,10 @@ inputs:
     required: false
     type: string
   complete:
-    description: "Filter PR subtasks by completion state. 'false' (default) returns only incomplete subtasks; 'true' returns only completed subtasks; '' (empty string) disables the filter and returns subtasks in any state."
+    description: "Filter PR subtasks by completion state. '' (default) disables the filter and returns subtasks in any state; 'false' returns only incomplete subtasks; 'true' returns only completed subtasks."
     required: false
     type: string
-    default: 'false'
+    default: ''
 outputs:
   subtask-ids:
     description: "JSON array of matching subtask gids. Empty array if none found."

--- a/actions/asana-fetch-pr-subtasks/asana-fetch-pr-subtasks.sh
+++ b/actions/asana-fetch-pr-subtasks/asana-fetch-pr-subtasks.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 #
-# Fetches PR review subtasks of a parent Asana task, optionally filtered by reviewer.
-# Reads env: ASANA_ACCESS_TOKEN, PARENT_TASK_ID, REVIEWER_USER, ASSIGNEE_FILTER, REPO_NAME
+# Fetches PR review subtasks of a parent Asana task, filtered by completion
+# state and optionally by reviewer.
+# Reads env: ASANA_ACCESS_TOKEN, PARENT_TASK_ID, REVIEWER_USER, ASSIGNEE_FILTER, REPO_NAME, COMPLETE
 # Writes:   subtask-ids=<json-array> to $GITHUB_OUTPUT
 #
 
@@ -23,13 +24,16 @@ subtasks=$(_fetch_subtasks "$PARENT_TASK_ID")
 # Filter rules:
 #   - task_name matches the "PR: ... (REPO_NAME)" naming convention
 #   - if ASSIGNEE_FILTER is non-empty, assignee gid must match it (else accept all)
+#   - task_completed must equal COMPLETE ('true' or 'false', defaults to 'false')
 subtask_ids=$(jq -c \
 	--arg prefix "$pr_prefix" \
 	--arg repo "$REPO_NAME" \
 	--arg assignee "$ASSIGNEE_FILTER" \
+	--arg complete "$COMPLETE" \
 	'[ .[]
 	   | select(.task_name | startswith($prefix) and endswith("(" + $repo + ")"))
 	   | select($assignee == "" or .assignee == $assignee)
+	   | select((.task_completed | tostring) == $complete)
 	   | .task_id
 	 ]' <<< "$subtasks")
 

--- a/actions/asana-fetch-pr-subtasks/asana-fetch-pr-subtasks.sh
+++ b/actions/asana-fetch-pr-subtasks/asana-fetch-pr-subtasks.sh
@@ -24,7 +24,8 @@ subtasks=$(_fetch_subtasks "$PARENT_TASK_ID")
 # Filter rules:
 #   - task_name matches the "PR: ... (REPO_NAME)" naming convention
 #   - if ASSIGNEE_FILTER is non-empty, assignee gid must match it (else accept all)
-#   - task_completed must equal COMPLETE ('true' or 'false', defaults to 'false')
+#   - if COMPLETE is non-empty, task_completed must equal it ('true' or 'false');
+#     if COMPLETE is empty, the completion-state filter is skipped (accept all).
 subtask_ids=$(jq -c \
 	--arg prefix "$pr_prefix" \
 	--arg repo "$REPO_NAME" \
@@ -33,7 +34,7 @@ subtask_ids=$(jq -c \
 	'[ .[]
 	   | select(.task_name | startswith($prefix) and endswith("(" + $repo + ")"))
 	   | select($assignee == "" or .assignee == $assignee)
-	   | select((.task_completed | tostring) == $complete)
+	   | select($complete == "" or (.task_completed | tostring) == $complete)
 	   | .task_id
 	 ]' <<< "$subtasks")
 


### PR DESCRIPTION
Two additions to the shared Asana action infra:

### 1. `complete` input on `asana-fetch-pr-subtasks`

Adds an optional filter so callers can fetch only incomplete subtasks, only completed ones, or any. 
- `complete: ''` (default) — no filter, returns subtasks in any state. Matches existing behavior, so this is non-breaking for current callers.
- `complete: 'false'` — only incomplete subtasks.
- `complete: 'true'` — only completed subtasks.

### 2. New `asana-extract-task-id` action

Wraps the grep+perl regex that pulls an Asana task gid out of a "Task/Issue URL:" line in a PR body. That regex is currently inlined across three workflows in apple-browsers (`create_asana_pr_subtask.yml`, `add_asana_comment_on_pr_review.yml`, `close_asana_pr_subtasks.yml`); 

Single input (`text`), single output (`task-id`, empty string if no match). Same regex as the inline code; supports both legacy `/0/` and current `/1/` Asana URL shapes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shared GitHub Actions only; default fetch behavior is unchanged and new inputs are additive for downstream workflow refactors.
> 
> **Overview**
> Adds a reusable **`asana-extract-task-id`** composite action that scans input text (typically a PR body) for a "Task/Issue URL:" line on `app.asana.com`, parses legacy `/0/` and current `/1/` URL shapes, and outputs **`task-id`** (digits only, or empty if none).
> 
> Extends **`asana-fetch-pr-subtasks`** with an optional **`complete`** input (`''` default, `'true'`, `'false'`) wired into the fetch script so PR review subtasks can be filtered by **`task_completed`** in addition to existing name/reviewer rules; default **`complete: ''`** keeps prior behavior (any completion state).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29bb876fb009332f89fc9c09348dd6424f5bed35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->